### PR TITLE
Add missing Builder.RealFloat.Functions module

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -92,6 +92,7 @@ library
     Data.Text.Fusion.Size
     Data.Text.IO.Internal
     Data.Text.Lazy.Builder.Functions
+    Data.Text.Lazy.Builder.RealFloat.Functions
     Data.Text.Lazy.Encoding.Fusion
     Data.Text.Lazy.Fusion
     Data.Text.Lazy.Search


### PR DESCRIPTION
`text-0.11.1.0` currently fails to install from Hackage, due to a missing module in the `other-modules` field:

```
Building text-0.11.1.0...

Data/Text/Lazy/Builder/RealFloat.hs:21:7:
    Could not find module `Data.Text.Lazy.Builder.RealFloat.Functions':
      Use -v to see a list of the files searched for.
cabal: Error: some packages failed to install:
text-0.11.1.0 failed during the building phase. The exception was:
ExitFailure 1
```

I added it in the attached commit.
