### PR TITLE
Fix build with GHC 7.3+

### DIFF
--- a/Data/Text/Array.hs
+++ b/Data/Text/Array.hs
@@ -64,7 +64,11 @@ import Control.Monad.ST (unsafeIOToST)
 import Data.Bits ((.&.), xor)
 import Data.Text.Unsafe.Base (inlinePerformIO)
 import Data.Text.UnsafeShift (shiftL, shiftR)
+#if __GLASGOW_HASKELL__ >= 703
+import Foreign.C.Types (CInt(CInt), CSize(CSize))
+#else
 import Foreign.C.Types (CInt, CSize)
+#endif
 import GHC.Base (ByteArray#, MutableByteArray#, Int(..),
                  indexWord16Array#, newByteArray#,
                  unsafeCoerce#, writeWord16Array#)


### PR DESCRIPTION
GHC 7.4 will have stricter rules about what types are allowed in FFI imports, see http://hackage.haskell.org/trac/ghc/ticket/5529

The `#if` is necessary as older GHCs don't export the newtype constructors.
