### PR TITLE
Documentation fix for breakOnAll.

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -1277,9 +1277,9 @@ breakOnEnd pat src = (reverse b, reverse a)
 --
 -- Examples:
 --
--- > find "::" ""
+-- > breakOnAll "::" ""
 -- > ==> []
--- > find "/" "a/b/c/"
+-- > breakOnAll "/" "a/b/c/"
 -- > ==> [("a", "/b/c/"), ("a/b", "/c/"), ("a/b/c", "/")]
 --
 -- In (unlikely) bad cases, this function's time complexity degrades
@@ -1314,7 +1314,7 @@ breakOnAll pat src@(Text arr off slen)
 -- For example, suppose you have a string that you want to split on
 -- the substring @\"::\"@, such as @\"foo::bar::quux\"@. Instead of
 -- searching for the index of @\"::\"@ and taking the substrings
--- before and after that index, you would instead use @find \"::\"@.
+-- before and after that index, you would instead use @breakOnAll \"::\"@.
 
 -- | /O(n)/ 'Text' index (subscript) operator, starting from 0.
 index :: Text -> Int -> Char

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -1056,7 +1056,7 @@ splitAtWord x (Chunk c@(T.Text arr off len) cs)
 -- >   where (prefix, match) = breakOn needle haystack
 --
 -- If you need to break a string by a substring repeatedly (e.g. you
--- want to break on every instance of a substring), use 'find'
+-- want to break on every instance of a substring), use 'breakOnAll'
 -- instead, as it has lower startup overhead.
 --
 -- This function is strict in its first argument, and lazy in its


### PR DESCRIPTION
Replaced occurences of 'find' in the 'breakOnAll' examples. Also
replaced 'find' with 'breakOnAll' in the Indexing discussion. Replaced
'find' with 'breakOnAll' in 'breakOn' discussion in Data.Text.Lazy.
