### PR TITLE
Bump depedency on integer-gmp

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -129,7 +129,7 @@ library
 
   if impl(ghc >= 6.11)
     cpp-options: -DINTEGER_GMP
-    build-depends: integer-gmp >= 0.2 && < 0.4
+    build-depends: integer-gmp >= 0.2 && < 0.5
 
   if impl(ghc >= 6.9) && impl(ghc < 6.11)
     cpp-options: -DINTEGER_GMP


### PR DESCRIPTION
This is required to build text with GHC 7.4.
