### PR TITLE
Use integer-simple if the integer-simple flag is set

### DIFF
--- a/Data/Text/Lazy/Builder/Int.hs
+++ b/Data/Text/Lazy/Builder/Int.hs
@@ -27,12 +27,16 @@ import GHC.Types (Int(..))
 #ifdef  __GLASGOW_HASKELL__
 # if __GLASGOW_HASKELL__ < 611
 import GHC.Integer.Internals
-# else
+# elif defined(INTEGER_GMP)
 import GHC.Integer.GMP.Internals
+# elif defined(INTEGER_SIMPLE)
+import GHC.Integer
+# else
+# error "You need to use either GMP or integer-simple."
 # endif
 #endif
 
-#ifdef INTEGER_GMP
+#if defined(INTEGER_GMP) || defined(INTEGER_SIMPLE)
 # define PAIR(a,b) (# a,b #)
 #else
 # define PAIR(a,b) (a,b)
@@ -93,8 +97,13 @@ int = decimal
 data T = T !Integer !Int
 
 integer :: Int -> Integer -> Builder
+#ifdef INTEGER_GMP
 integer 10 (S# i#) = decimal (I# i#)
 integer 16 (S# i#) = hexadecimal (I# i#)
+#else
+integer 10 i = decimal i
+integer 16 i = hexadecimal i
+#endif
 integer base i
     | i < 0     = singleton '-' <> go (-i)
     | otherwise = go i

--- a/text.cabal
+++ b/text.cabal
@@ -72,6 +72,10 @@ flag developer
   description: operate in developer mode
   default: False
 
+flag integer-simple
+  description: Use the simple integer library instead of GMP
+  default: False
+
 library
   c-sources: cbits/cbits.c
 
@@ -138,8 +142,13 @@ library
     cpp-options: -DASSERTS
 
   if impl(ghc >= 6.11)
-    cpp-options: -DINTEGER_GMP
-    build-depends: integer-gmp >= 0.2 && < 0.5
+    if flag(integer-simple)
+      cpp-options: -DINTEGER_SIMPLE
+      build-depends: integer-simple >= 0.1 && < 0.5
+    else
+      cpp-options: -DINTEGER_GMP
+      build-depends: integer-gmp >= 0.2 && < 0.5
+   
 
   if impl(ghc >= 6.9) && impl(ghc < 6.11)
     cpp-options: -DINTEGER_GMP


### PR DESCRIPTION
If the user sets -finteger-simple on installation then use integer-simple, avoiding some integer-gmp optimizations.

We could have a fancier build system that detects integer-simple vs integer-gmp but I figured it wasn't really worth while.
