### PR TITLE
Add left folds with early termination.

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -90,6 +90,8 @@ module Data.Text
     , foldl'
     , foldl1
     , foldl1'
+    , foldlE
+    , foldlE'
     , foldr
     , foldr1
 
@@ -771,6 +773,21 @@ foldl1 f t = S.foldl1 f (stream t)
 foldl1' :: (Char -> Char -> Char) -> Text -> Char
 foldl1' f t = S.foldl1' f (stream t)
 {-# INLINE foldl1' #-}
+
+-- | /O(n)/ 'foldlE', applied to a finalizer, a binary operator, a starting
+-- value (typically the left-identity of the operator), and a 'Text', reduces
+-- the 'Text' using the binary operator, from left to right.  In addition to
+-- 'foldl' it allows an early exit from the computation.
+-- Subject to fusion.
+foldlE :: (a -> c) -> (a -> Char -> P.Either c a) -> a -> Text -> c
+foldlE fin f z t = S.foldlE fin f z (stream t)
+{-# INLINE foldlE #-}
+
+-- | /O(n)/ A strict version of 'foldlE'.
+-- Subject to fusion.
+foldlE' :: (a -> c) -> (a -> Char -> P.Either c a) -> a -> Text -> c
+foldlE' fin f z t = S.foldlE' fin f z (stream t)
+{-# INLINE foldlE' #-}
 
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',

--- a/Data/Text/Fusion/Common.hs
+++ b/Data/Text/Fusion/Common.hs
@@ -52,6 +52,8 @@ module Data.Text.Fusion.Common
     , foldl'
     , foldl1
     , foldl1'
+    , foldlE
+    , foldlE'
     , foldr
     , foldr1
 
@@ -500,6 +502,33 @@ foldl1' f (Stream next s0 _len) = loop0_foldl1' s0
                              Skip s' -> loop_foldl1' z s'
                              Yield x s' -> loop_foldl1' (f z x) s'
 {-# INLINE [0] foldl1' #-}
+
+-- | foldlE, applied to a finalizer, a binary operator, a starting value
+-- (typically the left-identity of the operator), and a Stream, reduces the
+-- Stream using the binary operator, from left to right. In addition to 'foldl'
+-- it allows early exit from the computation.
+foldlE :: (b -> c) -> (b -> Char -> P.Either c b) -> b -> Stream Char -> c
+foldlE fin f z0 (Stream next s0 _len) = loop_foldl z0 s0
+    where
+      loop_foldl z !s = case next s of
+                          Done -> fin z
+                          Skip s' -> loop_foldl z s'
+                          Yield x s' -> case f z x of
+                                          P.Left c -> c
+                                          P.Right z' -> loop_foldl z' s'
+{-# INLINE [0] foldlE #-}
+
+-- | A strict version of 'foldlE'.
+foldlE' :: (b -> c) -> (b -> Char -> P.Either c b) -> b -> Stream Char -> c
+foldlE' fin f z0 (Stream next s0 _len) = loop_foldl z0 s0
+    where
+      loop_foldl !z !s = case next s of
+                          Done -> fin z
+                          Skip s' -> loop_foldl z s'
+                          Yield x s' -> case f z x of
+                                          P.Left c -> c
+                                          P.Right z' -> loop_foldl z' s'
+{-# INLINE [0] foldlE' #-}
 
 -- | 'foldr', applied to a binary operator, a starting value (typically the
 -- right-identity of the operator), and a stream, reduces the stream using the

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -97,6 +97,8 @@ module Data.Text.Lazy
     , foldl'
     , foldl1
     , foldl1'
+    , foldlE
+    , foldlE'
     , foldr
     , foldr1
 
@@ -729,6 +731,21 @@ foldl1 f t = S.foldl1 f (stream t)
 foldl1' :: (Char -> Char -> Char) -> Text -> Char
 foldl1' f t = S.foldl1' f (stream t)
 {-# INLINE foldl1' #-}
+
+-- | /O(n)/ 'foldlE', applied to a finalizer, a binary operator, a starting
+-- value (typically the left-identity of the operator), and a 'Text', reduces
+-- the 'Text' using the binary operator, from left to right.  In addition to
+-- 'foldl' it allows an early exit from the computation.
+-- Subject to fusion.
+foldlE :: (a -> c) -> (a -> Char -> P.Either c a) -> a -> Text -> c
+foldlE fin f z t = S.foldlE fin f z (stream t)
+{-# INLINE foldlE #-}
+
+-- | /O(n)/ A strict version of 'foldlE'.
+-- Subject to fusion.
+foldlE' :: (a -> c) -> (a -> Char -> P.Either c a) -> a -> Text -> c
+foldlE' fin f z t = S.foldlE' fin f z (stream t)
+{-# INLINE foldlE' #-}
 
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',


### PR DESCRIPTION
This generalization allows expressing left folds that don't need to process the entire sequence, such as various searching functions.

I'm working on some improvements to [listlike](http://hackage.haskell.org/package/ListLike) and this would be a handy common combinator.

A (somewhat artificial) example:

``` haskell
import Data.Text

findNth :: (Char -> Bool) -> Int -> Text -> Maybe Char
findNth p = foldlE' (const Nothing) f
  where
    f i x | p x         = if i == 0 then Left (Just x)
                                    else Right (i - 1)
          | otherwise   = Right i
```
