### PR TITLE
Remove "unzipping" from a heading

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -177,7 +177,7 @@ module Data.Text
     , findIndex
     , count
 
-    -- * Zipping and unzipping
+    -- * Zipping
     , zip
     , zipWith
 


### PR DESCRIPTION
Minor doc tweak. The heading says "Zipping and unzipping", but in reality there are only zipping functions. Alternatively, if desired, it could be worth adding unzip.
