### PR TITLE
Drop support for GHCs older than GHC 6.12

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -201,11 +201,7 @@ import Control.Exception (assert)
 #endif
 import Data.Char (isSpace)
 import Data.Data (Data(gfoldl, toConstr, gunfold, dataTypeOf))
-#if __GLASGOW_HASKELL__ >= 612
 import Data.Data (mkNoRepType)
-#else
-import Data.Data (mkNorepType)
-#endif
 import Control.Monad (foldM)
 import qualified Data.Text.Array as A
 import qualified Data.List as L
@@ -350,11 +346,7 @@ instance Data Text where
   gfoldl f z txt = z pack `f` (unpack txt)
   toConstr _     = P.error "Data.Text.Text.toConstr"
   gunfold _ _    = P.error "Data.Text.Text.gunfold"
-#if __GLASGOW_HASKELL__ >= 612
   dataTypeOf _   = mkNoRepType "Data.Text.Text"
-#else
-  dataTypeOf _   = mkNorepType "Data.Text.Text"
-#endif
 
 -- | /O(n)/ Compare two 'Text' values lexicographically.
 compareText :: Text -> Text -> Ordering

--- a/Data/Text/Encoding/Error.hs
+++ b/Data/Text/Encoding/Error.hs
@@ -39,11 +39,7 @@ module Data.Text.Encoding.Error
     ) where
 
 import Control.DeepSeq (NFData (..))
-#if __GLASGOW_HASKELL__ >= 610
 import Control.Exception (Exception, throw)
-#else
-import Control.Exception.Extensible (Exception, throw)
-#endif
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import Numeric (showHex)

--- a/Data/Text/IO/Internal.hs
+++ b/Data/Text/IO/Internal.hs
@@ -12,13 +12,10 @@
 
 module Data.Text.IO.Internal
     (
-#if __GLASGOW_HASKELL__ >= 612
       hGetLineWith
     , readChunk
-#endif
     ) where
 
-#if __GLASGOW_HASKELL__ >= 612
 import qualified Control.Exception as E
 import Data.IORef (readIORef, writeIORef)
 import Data.Text (Text)
@@ -163,4 +160,3 @@ readChunk hh@Handle__{..} buf = do
 
 sizeError :: String -> a
 sizeError loc = error $ "Data.Text.IO." ++ loc ++ ": bad internal buffer size"
-#endif

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -202,11 +202,7 @@ import Data.Int (Int64)
 import qualified Data.List as L
 import Data.Char (isSpace)
 import Data.Data (Data(gfoldl, toConstr, gunfold, dataTypeOf))
-#if __GLASGOW_HASKELL__ >= 612
 import Data.Data (mkNoRepType)
-#else
-import Data.Data (mkNorepType)
-#endif
 import Data.Monoid (Monoid(..))
 import Data.String (IsString(..))
 import qualified Data.Text as T
@@ -341,11 +337,7 @@ instance Data Text where
   gfoldl f z txt = z pack `f` (unpack txt)
   toConstr _     = error "Data.Text.Lazy.Text.toConstr"
   gunfold _ _    = error "Data.Text.Lazy.Text.gunfold"
-#if __GLASGOW_HASKELL__ >= 612
   dataTypeOf _   = mkNoRepType "Data.Text.Lazy.Text"
-#else
-  dataTypeOf _   = mkNorepType "Data.Text.Lazy.Text"
-#endif
 
 -- | /O(n)/ Convert a 'String' into a 'Text'.
 --

--- a/Data/Text/Lazy/Builder/Int.hs
+++ b/Data/Text/Lazy/Builder/Int.hs
@@ -33,9 +33,7 @@ import GHC.Types (Int(..))
 import Control.Monad.ST
 
 #ifdef  __GLASGOW_HASKELL__
-# if __GLASGOW_HASKELL__ < 611
-import GHC.Integer.Internals
-# elif defined(INTEGER_GMP)
+# if defined(INTEGER_GMP)
 import GHC.Integer.GMP.Internals
 # elif defined(INTEGER_SIMPLE)
 import GHC.Integer

--- a/Data/Text/Lazy/IO.hs
+++ b/Data/Text/Lazy/IO.hs
@@ -47,11 +47,6 @@ import System.IO (Handle, IOMode(..), hPutChar, openFile, stdin, stdout,
                   withFile)
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as L
-#if __GLASGOW_HASKELL__ <= 610
-import Data.Text.Lazy.Encoding (decodeUtf8)
-import qualified Data.ByteString.Char8 as S8
-import qualified Data.ByteString.Lazy.Char8 as L8
-#else
 import qualified Control.Exception as E
 import Control.Monad (when)
 import Data.IORef (readIORef)
@@ -65,7 +60,6 @@ import GHC.IO.Handle.Types (Handle__(..), HandleType(..))
 import System.IO (BufferMode(..), hGetBuffering, hSetBuffering)
 import System.IO.Error (isEOFError)
 import System.IO.Unsafe (unsafeInterleaveIO)
-#endif
 
 -- $performance
 --
@@ -99,9 +93,6 @@ appendFile p = withFile p AppendMode . flip hPutStr
 -- | Lazily read the remaining contents of a 'Handle'.  The 'Handle'
 -- will be closed after the read completes, or on error.
 hGetContents :: Handle -> IO Text
-#if __GLASGOW_HASKELL__ <= 610
-hGetContents = fmap decodeUtf8 . L8.hGetContents
-#else
 hGetContents h = do
   chooseGoodBuffering h
   wantReadableHandle "hGetContents" h $ \hh -> do
@@ -138,15 +129,10 @@ lazyReadBuffered h hh@Handle__{..} = do
                          then (hh', empty)
                          else (hh', L.singleton '\r')
            else E.throwIO (augmentIOError e "hGetContents" h)
-#endif
 
 -- | Read a single line from a handle.
 hGetLine :: Handle -> IO Text
-#if __GLASGOW_HASKELL__ <= 610
-hGetLine = fmap (decodeUtf8 . L8.fromChunks . (:[])) . S8.hGetLine
-#else
 hGetLine = hGetLineWith L.fromChunks
-#endif
 
 -- | Write a string to a handle.
 hPutStr :: Handle -> Text -> IO ()

--- a/Data/Text/Unsafe.hs
+++ b/Data/Text/Unsafe.hs
@@ -34,11 +34,7 @@ import Data.Text.Internal (Text(..))
 import Data.Text.Unsafe.Base (inlineInterleaveST, inlinePerformIO)
 import Data.Text.UnsafeChar (unsafeChr)
 import qualified Data.Text.Array as A
-#if __GLASGOW_HASKELL__ >= 611
 import GHC.IO (unsafeDupablePerformIO)
-#else
-import GHC.IOBase (unsafeDupablePerformIO)
-#endif
 
 -- | /O(1)/ A variant of 'head' for non-empty 'Text'. 'unsafeHead'
 -- omits the check for the empty case, so there is an obligation on

--- a/Data/Text/Unsafe/Base.hs
+++ b/Data/Text/Unsafe/Base.hs
@@ -18,11 +18,7 @@ module Data.Text.Unsafe.Base
 
 import GHC.ST (ST(..))
 #if defined(__GLASGOW_HASKELL__)
-# if __GLASGOW_HASKELL__ >= 611
 import GHC.IO (IO(IO))
-# else
-import GHC.IOBase (IO(IO))
-# endif
 import GHC.Base (realWorld#)
 #endif
 

--- a/text.cabal
+++ b/text.cabal
@@ -125,36 +125,25 @@ library
     Data.Text.Util
 
   build-depends:
-    array,
-    base       < 5,
-    bytestring >= 0.9
-  if impl(ghc >= 6.10)
-    build-depends:
-      ghc-prim, base >= 4, deepseq >= 1.1.0.0
-    cpp-options: -DHAVE_DEEPSEQ
-  else
-    build-depends: extensible-exceptions
-    extensions: ScopedTypeVariables
+    array      >= 0.3,
+    base       >= 4.2 && < 5,
+    bytestring >= 0.9,
+    deepseq    >= 1.1.0.0,
+    ghc-prim   >= 0.2
 
-  ghc-options: -Wall -funbox-strict-fields -O2
-  if impl(ghc >= 6.8)
-    ghc-options: -fwarn-tabs
+  cpp-options: -DHAVE_DEEPSEQ
+  ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)
     ghc-prof-options: -auto-all
     ghc-options: -Werror
     cpp-options: -DASSERTS
 
-  if impl(ghc >= 6.11)
-    if flag(integer-simple)
-      cpp-options: -DINTEGER_SIMPLE
-      build-depends: integer-simple >= 0.1 && < 0.5
-    else
-      cpp-options: -DINTEGER_GMP
-      build-depends: integer-gmp >= 0.2
-
-  if impl(ghc >= 6.9) && impl(ghc < 6.11)
+  if flag(integer-simple)
+    cpp-options: -DINTEGER_SIMPLE
+    build-depends: integer-simple >= 0.1 && < 0.5
+  else
     cpp-options: -DINTEGER_GMP
-    build-depends: integer >= 0.1 && < 0.2
+    build-depends: integer-gmp >= 0.2
 
 test-suite tests
   type:           exitcode-stdio-1.0
@@ -183,17 +172,12 @@ test-suite tests
     test-framework-hunit >= 0.2,
     test-framework-quickcheck2 >= 0.2
 
-  if impl(ghc >= 6.11)
-    if flag(integer-simple)
-      cpp-options: -DINTEGER_SIMPLE
-      build-depends: integer-simple >= 0.1 && < 0.5
-    else
-      cpp-options: -DINTEGER_GMP
-      build-depends: integer-gmp >= 0.2
-
-  if impl(ghc >= 6.9) && impl(ghc < 6.11)
+  if flag(integer-simple)
+    cpp-options: -DINTEGER_SIMPLE
+    build-depends: integer-simple >= 0.1 && < 0.5
+  else
     cpp-options: -DINTEGER_GMP
-    build-depends: integer >= 0.1 && < 0.2
+    build-depends: integer-gmp >= 0.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
As `text` doesn't build with GHC 6.10 anymore (see below), we can drop
support for GHC < 6.12; this commit evaluates compile time conditionals to
assume that GHC>=6.12 and adds lower bounds to build-depends to help
cabal fail early.

```
Building text-0.11.3.1...
Preprocessing library text-0.11.3.1...
[28 of 41] Compiling Data.Text.IO     ( Data/Text/IO.hs, dist/build/Data/Text/IO.o )
Data/Text/IO.hs:104:34:
    Not in scope: type constructor or class `Handle__'
Data/Text/IO.hs:105:20: Not in scope: data constructor `Handle__'
Data/Text/IO.hs:106:6: Not in scope: `isEOFError'
Data/Text/IO.hs:107:15: Not in scope: `readIORef'
Data/Text/IO.hs:107:25: Not in scope: `haCharBuffer'
Data/Text/IO.hs:108:20: Not in scope: `isEmptyBuffer'
Data/Text/IO.hs:109:22: Not in scope: `T.empty'
Data/Text/IO.hs:110:22: Not in scope: `T.singleton'
Data/Text/IO.hs:111:18: Not in scope: `E.throwIO'
Data/Text/IO.hs:111:29: Not in scope: `augmentIOError'
Data/Text/IO.hs:121:14: Not in scope: `wantReadableHandle'
Data/Text/IO.hs:123:21: Not in scope: data constructor `Handle__'
Data/Text/IO.hs:124:11: Not in scope: `readIORef'
Data/Text/IO.hs:124:21: Not in scope: `haCharBuffer'
Data/Text/IO.hs:125:9: Not in scope: `readChunk'
Data/Text/IO.hs:125:26: Not in scope: `E.catch'
```
