### PR TITLE
text.cabal: fix test suite (missing define to disable ASSERTS)

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -150,7 +150,7 @@ test-suite tests
     -Wall -threaded -O0 -rtsopts
 
   cpp-options:
-    -DASSERTS -DHAVE_DEEPSEQ
+    -DASSERTS -DHAVE_DEEPSEQ -DTEST_SUITE
 
   build-depends:
     HUnit >= 1.2,


### PR DESCRIPTION
> ```
> errors:
>   t_utf8_err: [Failed]
> ```
> 
> tests: Data/Text/Internal/Encoding/Utf8.hs:84:5-10: Assertion failed

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
