### PR TITLE
Add back `ensure 1` to avoid overflowing an output buffer

### DIFF
--- a/Data/Text/Encoding.hs
+++ b/Data/Text/Encoding.hs
@@ -384,7 +384,7 @@ encodeUtf8 (Text arr off len) = unsafeDupablePerformIO $ do
                       start newSize n m fp'
                 {-# INLINE ensure #-}
             case A.unsafeIndex arr n of
-             w| w <= 0x7F  -> do
+             w| w <= 0x7F  -> ensure 1 $ do
                   poke (ptr `plusPtr` m) (fromIntegral w :: Word8)
                   go (n+1) (m+1)
               | w <= 0x7FF -> ensure 2 $ do


### PR DESCRIPTION
The counter-example for the existing code is a string of length '2*n' that
starts with 'n' characters with codepoints in the range (0x7F, 0x7FF) and ends
with 'n' ASCII characters. All 'n' ASCII characters will be written after the
end of the output buffer.
