### PR TITLE
Mark some internal modules as not-home for Haddock

### DIFF
--- a/Data/Text/Internal.hs
+++ b/Data/Text/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -- |
 -- Module      : Data.Text.Internal

--- a/Data/Text/Internal/Builder.hs
+++ b/Data/Text/Internal/Builder.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, Rank2Types #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/Data/Text/Internal/Lazy.hs
+++ b/Data/Text/Internal/Lazy.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
 -- |
 -- Module      : Data.Text.Internal.Lazy
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan

--- a/Data/Text/Internal/Unsafe.hs
+++ b/Data/Text/Internal/Unsafe.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP, MagicHash, UnboxedTuples #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
 -- |
 -- Module      : Data.Text.Internal.Unsafe
 -- Copyright   : (c) 2009, 2010, 2011 Bryan O'Sullivan


### PR DESCRIPTION
Pretty trivial patch.
In most cases user is looking for official API, but right now a lot of interlinks point to internal modules.
