### PR TITLE
Remove incorrect deprecation doc message

### DIFF
--- a/Data/Text/Encoding.hs
+++ b/Data/Text/Encoding.hs
@@ -119,8 +119,6 @@ import qualified Data.Text.Internal.Fusion as F
 
 -- | /Deprecated/.  Decode a 'ByteString' containing 7-bit ASCII
 -- encoded text.
---
--- This function is deprecated.  Use 'decodeLatin1' instead.
 decodeASCII :: ByteString -> Text
 decodeASCII = decodeUtf8
 {-# DEPRECATED decodeASCII "Use decodeUtf8 instead" #-}


### PR DESCRIPTION
The pragma-based deprecation of `decodeASCII` correctly claims that `decodeUtf8` should be used (matching the implementation), while the documentation string of the function itself recommends `decodeLatin1` (which does not).
