### PR TITLE
Allow gunfold

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -1,5 +1,5 @@
 name:           text
-version:        1.1.0.1
+version:        1.1.1
 homepage:       https://github.com/bos/text
 bug-reports:    https://github.com/bos/text/issues
 synopsis:       An efficient packed Unicode text type.


### PR DESCRIPTION
The motivation for the `mkNoRepType` `Data` instance for `Text` appears to have been to follow the idiom established by `Data.Map` and `Data.Set` for dealing with encapsulation.

We changed the behavior of those types to allow `gunfold` by the use of a "virtual" constructor back in 2012.

http://markmail.org/message/trovdc6zkphyi3cr#query:+page:1+mid:a46der3iacwjcf6n+state:results

This patch would allow the same behavior to work for `Text`, and just silently improve the experience of generic programmers across the board.
