### PR TITLE
Make developer flag manual-only

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -71,6 +71,7 @@ extra-source-files:
 flag developer
   description: operate in developer mode
   default: False
+  manual: True
 
 flag integer-simple
   description: Use the simple integer library instead of GMP


### PR DESCRIPTION
This makes the cabal constraint solver's job easier (fewer
combinations to try) and makes it impossible for it to set developer
to True when installing the library.
