### PR TITLE
updated upperBound to return upper instead of lower bound from size hint

### DIFF
--- a/Data/Text/Internal/Fusion/Size.hs
+++ b/Data/Text/Internal/Fusion/Size.hs
@@ -135,7 +135,7 @@ larger _ _ = Unknown
 
 -- | Compute the maximum size from a size hint, if possible.
 upperBound :: Int -> Size -> Int
-upperBound _ (Between n _) = n
+upperBound _ (Between _ n) = n
 upperBound k _             = k
 {-# INLINE upperBound #-}
 


### PR DESCRIPTION
Small change that seems to fix fusion performance from #76.
Probably was forcing a bunch of extra allocing & copying.

|  | HEAD | Post-Patch |
| --- | --- | --- |
| Pure/toUpper/Text+tiny | 457.8308 ns | 356.0704 ns |
| Pure/toUpper/Text+ascii | 4.543261 ms | 4.431779 ms |
