### PR TITLE
Improve docs for `replace`.

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -666,11 +666,23 @@ reverse :: Text -> Text
 reverse t = S.reverse (stream t)
 {-# INLINE reverse #-}
 
--- | /O(m+n)/ Replace every occurrence of one substring with another.
+-- | /O(m+n)/ Replace every occurrence of @needle@ in @haystack@ with @repl@.
+--
+-- If @needle@ occurs in @repl@, it won't be replaced twice:
+--
+-- > replace "oo" "foo" "oo" == "foo"
+--
+-- If several instances of @needle@ overlap, only the first one will be
+-- replaced:
+--
+-- > replace "ofo" "bar" "ofofo" == "barfo"
 --
 -- In (unlikely) bad cases, this function's time complexity degrades
 -- towards /O(n*m)/.
-replace :: Text -> Text -> Text -> Text
+replace :: Text        -- ^ @needle@ to search for
+        -> Text        -- ^ @repl@ to replace @needle@ with
+        -> Text        -- ^ @haystack@ in which to search
+        -> Text
 replace needle@(Text _      _      neeLen)
                (Text repArr repOff repLen)
       haystack@(Text hayArr hayOff hayLen)


### PR DESCRIPTION
As said on #haskell:

```
(09:08:42 PM) c_wraith: Hmm.  that's a function that really does need better
docs - the type signature doesn't pin down argument order.
```
