### PR TITLE
Remove the default value for the integer-simple flag.

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -71,7 +71,6 @@ flag developer
 
 flag integer-simple
   description: Use the simple integer library instead of GMP
-  default: False
 
 library
   c-sources:    cbits/cbits.c


### PR DESCRIPTION
Using a default seems to require users to explicitly override the flag if they
want to enable it. Leaving it off allows Cabal to automatically figure out the
proper value of the flag, which is handy, especially when text is at the bottom
of a long dependency chain.
