### PR TITLE
Add support for `deepseq-1.4.0.0` (addresses #100)

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -199,7 +199,7 @@ import Prelude (Char, Bool(..), Int, Maybe(..), String,
                 (&&), (||), (+), (-), (.), ($), ($!), (>>),
                 not, return, otherwise, quot)
 #if defined(HAVE_DEEPSEQ)
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData(rnf))
 #endif
 #if defined(ASSERTS)
 import Control.Exception (assert)
@@ -346,7 +346,7 @@ instance Exts.IsList Text where
 #endif
 
 #if defined(HAVE_DEEPSEQ)
-instance NFData Text
+instance NFData Text where rnf !_ = ()
 #endif
 
 -- | This instance preserves data abstraction at the cost of inefficiency.


### PR DESCRIPTION
The default method implementation has changed in `deepseq-1.4.0.0`.
(see haskell/deepseq#1 for details). This simply sets the `rnf`
implementation explicitly to avoid relying on the default method's
semantics.
