### PR TITLE
Use lower upper bound for pre-allocation in `encodeUtf8`

### DIFF
--- a/Data/Text/Encoding.hs
+++ b/Data/Text/Encoding.hs
@@ -373,7 +373,7 @@ encodeUtf8 :: Text -> ByteString
 encodeUtf8 (Text arr off len)
   | len == 0  = B.empty
   | otherwise = unsafeDupablePerformIO $ do
-  fp <- mallocByteString (len*4)
+  fp <- mallocByteString (len*3) -- see https://github.com/haskell/text/issues/194 for why len*3 is enough
   withForeignPtr fp $ \ptr ->
     with ptr $ \destPtr -> do
       c_encode_utf8 destPtr (A.aBA arr) (fromIntegral off) (fromIntegral len)


### PR DESCRIPTION
The rationale is that we encode from UTF16 code-units to UTF8, and
to encode a *single* UTF16 code-unit we need at most 3-byte in UTF8.
Wherease 4-byte UTF8 encodings would require surrogate UTF16 pairs.

Fixes #194