### PR TITLE
Fix #197

### DIFF
--- a/Data/Text/Internal/Fusion/Common.hs
+++ b/Data/Text/Internal/Fusion/Common.hs
@@ -857,7 +857,8 @@ indexI (Stream next s0 _len) n0
 -- returns a stream containing those characters that satisfy the
 -- predicate.
 filter :: (Char -> Bool) -> Stream Char -> Stream Char
-filter p (Stream next0 s0 len) = Stream next s0 len -- HINT maybe too high
+filter p (Stream next0 s0 len) =
+    Stream next s0 (len - unknownSize) -- HINT maybe too high
   where
     next !s = case next0 s of
                 Done                   -> Done

--- a/tests/Tests/Regressions.hs
+++ b/tests/Tests/Regressions.hs
@@ -72,9 +72,10 @@ mapAccumL_resize = do
   assertEqual "mapAccumL should correctly size buffers for two-word results"
              (count * 2) (T.lengthWord16 (snd val))
 
+-- See GitHub #197
 t197 :: IO ()
 t197 =
-  assertBool "filtered length is incorrect" (currencyParser "0,00")
+    assertBool "length (filter (==',') \"0,00\") should be 1" (currencyParser "0,00")
   where
     currencyParser x = cond == 1
       where

--- a/tests/Tests/Regressions.hs
+++ b/tests/Tests/Regressions.hs
@@ -72,6 +72,15 @@ mapAccumL_resize = do
   assertEqual "mapAccumL should correctly size buffers for two-word results"
              (count * 2) (T.lengthWord16 (snd val))
 
+t197 :: IO ()
+t197 =
+  assertBool "filtered length is incorrect" (currencyParser "0,00")
+  where
+    currencyParser x = cond == 1
+      where
+        cond = length fltr
+        fltr = filter (== ',') x
+
 tests :: F.Test
 tests = F.testGroup "Regressions"
     [ F.testCase "hGetContents_crash" hGetContents_crash
@@ -79,4 +88,5 @@ tests = F.testGroup "Regressions"
     , F.testCase "mapAccumL_resize" mapAccumL_resize
     , F.testCase "replicate_crash" replicate_crash
     , F.testCase "utf8_decode_unsafe" utf8_decode_unsafe
+    , F.testCase "t197" t197
     ]

--- a/text.cabal
+++ b/text.cabal
@@ -168,7 +168,7 @@ test-suite tests
   include-dirs:   include
 
   ghc-options:
-    -Wall -threaded -O0 -rtsopts
+    -Wall -threaded -O1 -rtsopts
 
   cpp-options:
     -DASSERTS -DHAVE_DEEPSEQ -DTEST_SUITE


### PR DESCRIPTION
This fixes a variety of size hint bugs in `text`'s fusion framework. These could manifest in a variety of issues similar to #197.