### PR TITLE
use environments to lazily initialize benchmarks

### DIFF
--- a/benchmarks/haskell/Benchmarks/Builder.hs
+++ b/benchmarks/haskell/Benchmarks/Builder.hs
@@ -23,8 +23,8 @@ import qualified Data.Text.Lazy.Builder as LTB
 import qualified Data.Text.Lazy.Builder.Int as Int
 import Data.Int (Int64)
 
-benchmark :: IO Benchmark
-benchmark = return $ bgroup "Builder"
+benchmark :: Benchmark
+benchmark = bgroup "Builder"
     [ bgroup "Comparison"
       [ bench "LazyText" $ nf
           (LT.length . LTB.toLazyText . mconcat . map LTB.fromText) texts

--- a/benchmarks/haskell/Benchmarks/Concat.hs
+++ b/benchmarks/haskell/Benchmarks/Concat.hs
@@ -6,8 +6,8 @@ import Control.Monad.Trans.Writer
 import Criterion (Benchmark, bgroup, bench, whnf)
 import Data.Text as T
 
-benchmark :: IO Benchmark
-benchmark = return $ bgroup "Concat"
+benchmark :: Benchmark
+benchmark = bgroup "Concat"
   [ bench "append" $ whnf (append4 "Text 1" "Text 2" "Text 3") "Text 4"
   , bench "concat" $ whnf (concat4 "Text 1" "Text 2" "Text 3") "Text 4"
   , bench "write"  $ whnf (write4  "Text 1" "Text 2" "Text 3") "Text 4"

--- a/benchmarks/haskell/Benchmarks/EncodeUtf8.hs
+++ b/benchmarks/haskell/Benchmarks/EncodeUtf8.hs
@@ -18,9 +18,9 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 
-benchmark :: String -> IO Benchmark
-benchmark string = do
-    return $ bgroup "EncodeUtf8"
+benchmark :: String -> Benchmark
+benchmark string =
+    bgroup "EncodeUtf8"
         [ bench "Text"     $ whnf (B.length . T.encodeUtf8)   text
         , bench "LazyText" $ whnf (BL.length . TL.encodeUtf8) lazyText
         ]

--- a/benchmarks/haskell/Benchmarks/FileRead.hs
+++ b/benchmarks/haskell/Benchmarks/FileRead.hs
@@ -19,8 +19,8 @@ import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import qualified Data.Text.Lazy.IO as LT
 
-benchmark :: FilePath -> IO Benchmark
-benchmark p = return $ bgroup "FileRead"
+benchmark :: FilePath -> Benchmark
+benchmark p = bgroup "FileRead"
     [ bench "String" $ whnfIO $ length <$> readFile p
     , bench "ByteString" $ whnfIO $ SB.length <$> SB.readFile p
     , bench "LazyByteString" $ whnfIO $ LB.length <$> LB.readFile p

--- a/benchmarks/haskell/Benchmarks/FoldLines.hs
+++ b/benchmarks/haskell/Benchmarks/FoldLines.hs
@@ -16,8 +16,8 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
-benchmark :: FilePath -> IO Benchmark
-benchmark fp = return $ bgroup "ReadLines"
+benchmark :: FilePath -> Benchmark
+benchmark fp = bgroup "ReadLines"
     [ bench "Text"       $ withHandle $ foldLinesT (\n _ -> n + 1) (0 :: Int)
     , bench "ByteString" $ withHandle $ foldLinesB (\n _ -> n + 1) (0 :: Int)
     ]

--- a/benchmarks/haskell/Benchmarks/Mul.hs
+++ b/benchmarks/haskell/Benchmarks/Mul.hs
@@ -1,4 +1,7 @@
-module Benchmarks.Mul (benchmark) where
+module Benchmarks.Mul
+    ( initEnv
+    , benchmark
+    ) where
 
 import Control.Exception (evaluate)
 import Criterion.Main
@@ -12,16 +15,21 @@ oldMul m n
     | m <= maxBound `quot` n = m * n
     | otherwise              = error "overflow"
 
-benchmark :: IO Benchmark
-benchmark = do
-  _ <- evaluate testVector32
-  _ <- evaluate testVector64
-  return $ bgroup "Mul" [
-      bench "oldMul" $ whnf (U.map (uncurry oldMul)) testVector64
-    , bench "mul64" $ whnf (U.map (uncurry mul64)) testVector64
-    , bench "*64" $ whnf (U.map (uncurry (*))) testVector64
-    , bench "mul32" $ whnf (U.map (uncurry mul32)) testVector32
-    , bench "*32" $ whnf (U.map (uncurry (*))) testVector32
+type Env = (U.Vector (Int32,Int32), U.Vector (Int64,Int64))
+
+initEnv :: IO Env
+initEnv = do
+    x <- evaluate testVector32
+    y <- evaluate testVector64
+    return (x, y)
+
+benchmark :: Env -> Benchmark
+benchmark ~(tv32, tv64) = bgroup "Mul"
+    [ bench "oldMul" $ whnf (U.map (uncurry oldMul)) tv64
+    , bench "mul64" $ whnf (U.map (uncurry mul64)) tv64
+    , bench "*64" $ whnf (U.map (uncurry (*))) tv64
+    , bench "mul32" $ whnf (U.map (uncurry mul32)) tv32
+    , bench "*32" $ whnf (U.map (uncurry (*))) tv32
     ]
 
 testVector64 :: U.Vector (Int64,Int64)

--- a/benchmarks/haskell/Benchmarks/Programs/BigTable.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/BigTable.hs
@@ -18,8 +18,8 @@ import Data.Text.Lazy.IO (hPutStr)
 import System.IO (Handle)
 import qualified Data.Text as T
 
-benchmark :: Handle -> IO Benchmark
-benchmark sink = return $ bench "BigTable" $ whnfIO $ do
+benchmark :: Handle -> Benchmark
+benchmark sink = bench "BigTable" $ whnfIO $ do
     hPutStr sink "Content-Type: text/html\n\n<table>"
     hPutStr sink . toLazyText . makeTable =<< rows
     hPutStr sink "</table>"

--- a/benchmarks/haskell/Benchmarks/Programs/Cut.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/Cut.hs
@@ -29,8 +29,8 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.Text.Lazy.IO as TL
 
-benchmark :: FilePath -> Handle -> Int -> Int -> IO Benchmark
-benchmark p sink from to = return $ bgroup "Cut"
+benchmark :: FilePath -> Handle -> Int -> Int -> Benchmark
+benchmark p sink from to = bgroup "Cut"
     [ bench' "String" string
     , bench' "ByteString" byteString
     , bench' "LazyByteString" lazyByteString

--- a/benchmarks/haskell/Benchmarks/Programs/Fold.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/Fold.hs
@@ -28,8 +28,8 @@ import qualified Data.Text.Lazy.Builder as TLB
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
 
-benchmark :: FilePath -> Handle -> IO Benchmark
-benchmark i o = return $
+benchmark :: FilePath -> Handle -> Benchmark
+benchmark i o =
     bench "Fold" $ whnfIO $ T.readFile i >>= TL.hPutStr o . fold 80
 
 -- | We represent a paragraph by a word list

--- a/benchmarks/haskell/Benchmarks/Programs/Sort.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/Sort.hs
@@ -33,8 +33,8 @@ import qualified Data.Text.Lazy.Builder as TLB
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.Text.Lazy.IO as TL
 
-benchmark :: FilePath -> Handle -> IO Benchmark
-benchmark i o = return $ bgroup "Sort"
+benchmark :: FilePath -> Handle -> Benchmark
+benchmark i o = bgroup "Sort"
     [ bench "String" $ whnfIO $ readFile i >>= hPutStr o . string
     , bench "ByteString" $ whnfIO $ B.readFile i >>= B.hPutStr o . byteString
     , bench "LazyByteString" $ whnfIO $

--- a/benchmarks/haskell/Benchmarks/Programs/StripTags.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/StripTags.hs
@@ -24,8 +24,8 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 
-benchmark :: FilePath -> Handle -> IO Benchmark
-benchmark i o = return $ bgroup "StripTags"
+benchmark :: FilePath -> Handle -> Benchmark
+benchmark i o = bgroup "StripTags"
     [ bench "String" $ whnfIO $ readFile i >>= hPutStr o . string
     , bench "ByteString" $ whnfIO $ B.readFile i >>= B.hPutStr o . byteString
     , bench "Text" $ whnfIO $ T.readFile i >>= T.hPutStr o . text

--- a/benchmarks/haskell/Benchmarks/Programs/Throughput.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/Throughput.hs
@@ -27,8 +27,8 @@ import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.Text.Lazy.IO as TL
 
-benchmark :: FilePath -> Handle -> IO Benchmark
-benchmark fp sink = return $ bgroup "Throughput"
+benchmark :: FilePath -> Handle -> Benchmark
+benchmark fp sink = bgroup "Throughput"
     [ bench "String" $ whnfIO $ readFile fp >>= hPutStr sink
     , bench "ByteString" $ whnfIO $ B.readFile fp >>= B.hPutStr sink
     , bench "LazyByteString" $ whnfIO $ BL.readFile fp >>= BL.hPutStr sink

--- a/benchmarks/haskell/Benchmarks/ReadNumbers.hs
+++ b/benchmarks/haskell/Benchmarks/ReadNumbers.hs
@@ -17,7 +17,8 @@
 -- * Lexing/parsing of different numerical types
 --
 module Benchmarks.ReadNumbers
-    ( benchmark
+    ( initEnv
+    , benchmark
     ) where
 
 import Criterion (Benchmark, bgroup, bench, whnf)
@@ -33,8 +34,10 @@ import qualified Data.Text.Lazy.IO as TL
 import qualified Data.Text.Lazy.Read as TL
 import qualified Data.Text.Read as T
 
-benchmark :: FilePath -> IO Benchmark
-benchmark fp = do
+type Env = ([String], [T.Text], [TL.Text], [B.ByteString], [BL.ByteString])
+
+initEnv :: FilePath -> IO Env
+initEnv fp = do
     -- Read all files into lines: string, text, lazy text, bytestring, lazy
     -- bytestring
     s <- lines `fmap` readFile fp
@@ -42,7 +45,11 @@ benchmark fp = do
     tl <- TL.lines `fmap` TL.readFile fp
     b <- B.lines `fmap` B.readFile fp
     bl <- BL.lines `fmap` BL.readFile fp
-    return $ bgroup "ReadNumbers"
+    return (s, t, tl, b, bl)
+
+benchmark :: Env -> Benchmark
+benchmark ~(s, t, tl, b, bl) =
+    bgroup "ReadNumbers"
         [ bench "DecimalString"     $ whnf (int . string readDec) s
         , bench "HexadecimalString" $ whnf (int . string readHex) s
         , bench "DoubleString"      $ whnf (double . string readFloat) s

--- a/benchmarks/haskell/Benchmarks/Replace.hs
+++ b/benchmarks/haskell/Benchmarks/Replace.hs
@@ -7,6 +7,7 @@
 --
 module Benchmarks.Replace
     ( benchmark
+    , initEnv
     ) where
 
 import Criterion (Benchmark, bgroup, bench, nf)
@@ -20,13 +21,19 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import qualified Data.Text.Lazy.IO as TL
 
-benchmark :: FilePath -> String -> String -> IO Benchmark
-benchmark fp pat sub = do
+type Env = (T.Text, B.ByteString, TL.Text, BL.ByteString)
+
+initEnv :: FilePath -> IO Env
+initEnv fp = do
     tl <- TL.readFile fp
     bl <- BL.readFile fp
     let !t = TL.toStrict tl
         !b = T.encodeUtf8 t
-    return $ bgroup "Replace" [
+    return (t, b, tl, bl)
+
+benchmark :: String -> String -> Env -> Benchmark
+benchmark pat sub ~(t, b, tl, bl) =
+    bgroup "Replace" [
           bench "Text"           $ nf (T.length . T.replace tpat tsub) t
         , bench "ByteString"     $ nf (BL.length . B.replace bpat bsub) b
         , bench "LazyText"       $ nf (TL.length . TL.replace tlpat tlsub) tl

--- a/benchmarks/haskell/Benchmarks/Search.hs
+++ b/benchmarks/haskell/Benchmarks/Search.hs
@@ -5,7 +5,8 @@
 -- * Searching all occurences of a pattern using library routines
 --
 module Benchmarks.Search
-    ( benchmark
+    ( initEnv
+    , benchmark
     ) where
 
 import Criterion (Benchmark, bench, bgroup, whnf)
@@ -19,13 +20,19 @@ import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
 
-benchmark :: FilePath -> T.Text -> IO Benchmark
-benchmark fp needleT = do
+type Env = (B.ByteString, BL.ByteString, T.Text, TL.Text)
+
+initEnv :: FilePath -> IO Env
+initEnv fp = do
     b  <- B.readFile fp
     bl <- BL.readFile fp
     t  <- T.readFile fp
     tl <- TL.readFile fp
-    return $ bgroup "FileIndices"
+    return (b, bl, t, tl)
+
+benchmark :: T.Text -> Env -> Benchmark
+benchmark needleT ~(b, bl, t, tl) =
+    bgroup "FileIndices"
         [ bench "ByteString"     $ whnf (byteString needleB)     b
         , bench "LazyByteString" $ whnf (lazyByteString needleB) bl
         , bench "Text"           $ whnf (text needleT)           t

--- a/benchmarks/haskell/Benchmarks/WordFrequencies.hs
+++ b/benchmarks/haskell/Benchmarks/WordFrequencies.hs
@@ -9,7 +9,8 @@
 -- * Comparing: Eq/Ord instances
 --
 module Benchmarks.WordFrequencies
-    ( benchmark
+    ( initEnv
+    , benchmark
     ) where
 
 import Criterion (Benchmark, bench, bgroup, whnf)
@@ -21,12 +22,18 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
-benchmark :: FilePath -> IO Benchmark
-benchmark fp = do
+type Env = (String, B.ByteString, T.Text)
+
+initEnv :: FilePath -> IO Env
+initEnv fp = do
     s <- readFile fp
     b <- B.readFile fp
     t <- T.readFile fp
-    return $ bgroup "WordFrequencies"
+    return (s, b, t)
+
+benchmark :: Env -> Benchmark
+benchmark ~(s, b, t) =
+    bgroup "WordFrequencies"
         [ bench "String"     $ whnf (frequencies . words . map toLower)     s
         , bench "ByteString" $ whnf (frequencies . B.words . B.map toLower) b
         , bench "Text"       $ whnf (frequencies . T.words . T.toLower)     t


### PR DESCRIPTION
if we only need to run a few benchmarks,
e.g. `text-benchmarks Pure/drop/Text+tiny`
it's wasteful to initialize all of them
(and read all the test data in memory - all
the test data is a few hundreds of MB, but
we read it in several tests, as different types,
and most seriously, as String - which turns this
into GBs of memory)