### PR TITLE
Move lazy builder internals to Internal.Lazy.Builder

### DIFF
--- a/Data/Text/Internal/Lazy/Builder.hs
+++ b/Data/Text/Internal/Lazy/Builder.hs
@@ -3,7 +3,7 @@
 
 -----------------------------------------------------------------------------
 -- |
--- Module      : Data.Text.Internal.Builder
+-- Module      : Data.Text.Internal.Lazy.Builder
 -- Copyright   : (c) 2013 Bryan O'Sullivan
 --               (c) 2010 Johan Tibell
 -- License     : BSD-style (see LICENSE)
@@ -35,7 +35,7 @@
 --
 -----------------------------------------------------------------------------
 
-module Data.Text.Internal.Builder
+module Data.Text.Internal.Lazy.Builder
    ( -- * Public API
      -- ** The Builder type
      Builder

--- a/Data/Text/Internal/Lazy/Builder/Functions.hs
+++ b/Data/Text/Internal/Lazy/Builder/Functions.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MagicHash #-}
 
 -- |
--- Module      : Data.Text.Internal.Builder.Functions
+-- Module      : Data.Text.Internal.Lazy.Builder.Functions
 -- Copyright   : (c) 2011 MailRank, Inc.
 --
 -- License     : BSD-style
@@ -15,7 +15,7 @@
 --
 -- Useful functions and combinators.
 
-module Data.Text.Internal.Builder.Functions
+module Data.Text.Internal.Lazy.Builder.Functions
     (
       (<>)
     , i2d

--- a/Data/Text/Internal/Lazy/Builder/Int/Digits.hs
+++ b/Data/Text/Internal/Lazy/Builder/Int/Digits.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- Module:      Data.Text.Internal.Builder.Int.Digits
+-- Module:      Data.Text.Internal.Lazy.Builder.Int.Digits
 -- Copyright:   (c) 2013 Bryan O'Sullivan
 -- License:     BSD-style
 -- Maintainer:  Bryan O'Sullivan <bos@serpentine.com>
@@ -14,7 +14,7 @@
 -- This module exists because the C preprocessor does things that we
 -- shall not speak of when confronted with Haskell multiline strings.
 
-module Data.Text.Internal.Builder.Int.Digits (digits) where
+module Data.Text.Internal.Lazy.Builder.Int.Digits (digits) where
 
 import Data.ByteString.Char8 (ByteString)
 

--- a/Data/Text/Internal/Lazy/Builder/RealFloat/Functions.hs
+++ b/Data/Text/Internal/Lazy/Builder/RealFloat/Functions.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 -- |
--- Module:    Data.Text.Internal.Builder.RealFloat.Functions
+-- Module:    Data.Text.Internal.Lazy.Builder.RealFloat.Functions
 -- Copyright: (c) The University of Glasgow 1994-2002
 -- License:   see libraries/base/LICENSE
 --
@@ -9,7 +9,7 @@
 -- API or name. Functions in this module may not check or enforce
 -- preconditions expected by public modules. Use at your own risk!
 
-module Data.Text.Internal.Builder.RealFloat.Functions
+module Data.Text.Internal.Lazy.Builder.RealFloat.Functions
     (
       roundTo
     ) where

--- a/Data/Text/Lazy/Builder.hs
+++ b/Data/Text/Lazy/Builder.hs
@@ -55,4 +55,4 @@ module Data.Text.Lazy.Builder
    , flush
    ) where
 
-import Data.Text.Internal.Builder
+import Data.Text.Internal.Lazy.Builder

--- a/Data/Text/Lazy/Builder/Int.hs
+++ b/Data/Text/Lazy/Builder/Int.hs
@@ -23,9 +23,9 @@ module Data.Text.Lazy.Builder.Int
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Monoid (mempty)
 import qualified Data.ByteString.Unsafe as B
-import Data.Text.Internal.Builder.Functions ((<>), i2d)
-import Data.Text.Internal.Builder
-import Data.Text.Internal.Builder.Int.Digits (digits)
+import Data.Text.Internal.Lazy.Builder.Functions ((<>), i2d)
+import Data.Text.Internal.Lazy.Builder
+import Data.Text.Internal.Lazy.Builder.Int.Digits (digits)
 import Data.Text.Array
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import GHC.Base (quotInt, remInt)

--- a/Data/Text/Lazy/Builder/RealFloat.hs
+++ b/Data/Text/Lazy/Builder/RealFloat.hs
@@ -19,9 +19,9 @@ module Data.Text.Lazy.Builder.RealFloat
 
 import Data.Array.Base (unsafeAt)
 import Data.Array.IArray
-import Data.Text.Internal.Builder.Functions ((<>), i2d)
+import Data.Text.Internal.Lazy.Builder.Functions ((<>), i2d)
 import Data.Text.Lazy.Builder.Int (decimal)
-import Data.Text.Internal.Builder.RealFloat.Functions (roundTo)
+import Data.Text.Internal.Lazy.Builder.RealFloat.Functions (roundTo)
 import Data.Text.Lazy.Builder
 import qualified Data.Text as T
 #if MIN_VERSION_base(4,11,0)

--- a/tests/text-tests.cabal
+++ b/tests/text-tests.cabal
@@ -109,12 +109,12 @@ library
     Data.Text.Internal
     Data.Text.Lazy
     Data.Text.Lazy.Builder
-    Data.Text.Internal.Builder.Functions
+    Data.Text.Internal.Lazy.Builder.Functions
     Data.Text.Lazy.Builder.Int
-    Data.Text.Internal.Builder.Int.Digits
-    Data.Text.Internal.Builder
+    Data.Text.Internal.Lazy.Builder.Int.Digits
+    Data.Text.Internal.Lazy.Builder
     Data.Text.Lazy.Builder.RealFloat
-    Data.Text.Internal.Builder.RealFloat.Functions
+    Data.Text.Internal.Lazy.Builder.RealFloat.Functions
     Data.Text.Lazy.Encoding
     Data.Text.Internal.Lazy.Encoding.Fusion
     Data.Text.Internal.Lazy.Fusion

--- a/text.cabal
+++ b/text.cabal
@@ -93,10 +93,6 @@ library
     Data.Text.Foreign
     Data.Text.IO
     Data.Text.Internal
-    Data.Text.Internal.Builder
-    Data.Text.Internal.Builder.Functions
-    Data.Text.Internal.Builder.Int.Digits
-    Data.Text.Internal.Builder.RealFloat.Functions
     Data.Text.Internal.Encoding.Fusion
     Data.Text.Internal.Encoding.Fusion.Common
     Data.Text.Internal.Encoding.Utf16
@@ -110,6 +106,10 @@ library
     Data.Text.Internal.Fusion.Types
     Data.Text.Internal.IO
     Data.Text.Internal.Lazy
+    Data.Text.Internal.Lazy.Builder
+    Data.Text.Internal.Lazy.Builder.Functions
+    Data.Text.Internal.Lazy.Builder.Int.Digits
+    Data.Text.Internal.Lazy.Builder.RealFloat.Functions
     Data.Text.Internal.Lazy.Encoding.Fusion
     Data.Text.Internal.Lazy.Fusion
     Data.Text.Internal.Lazy.Search


### PR DESCRIPTION
It seems these internals were not moved in 2010 when `Data.Text.Builder` became `Data.Text.Lazy.Builder`.

If/when we add a strict text builder, these will be in the way.