### PR TITLE
faster compareText

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -410,17 +410,20 @@ textDataType = mkDataType "Data.Text.Text" [packConstr]
 
 -- | /O(n)/ Compare two 'Text' values lexicographically.
 compareText :: Text -> Text -> Ordering
-compareText ta@(Text _arrA _offA lenA) tb@(Text _arrB _offB lenB)
-    | lenA == 0 && lenB == 0 = EQ
-    | otherwise              = go 0 0
+compareText (Text arrA offA lenA) (Text arrB offB lenB)
+    | lenA == 0 || lenB == 0 = compare lenA lenB
+    | otherwise              = go offA offB
   where
+    ea = offA + lenA
+    eb = offB + lenB
     go !i !j
-        | i >= lenA || j >= lenB = compare lenA lenB
-        | a < b                  = LT
-        | a > b                  = GT
-        | otherwise              = go (i+di) (j+dj)
-      where Iter a di = iter ta i
-            Iter b dj = iter tb j
+        | i >= ea || j >= eb = compare lenA lenB
+        | a < b              = LT
+        | a > b              = GT
+        | otherwise          = go (i+1) (j+1)
+      where
+      a = A.unsafeIndex arrA i
+      b = A.unsafeIndex arrB j
 
 -- -----------------------------------------------------------------------------
 -- * Conversion to/from 'Text'

--- a/benchmarks/haskell/Benchmarks/Pure.hs
+++ b/benchmarks/haskell/Benchmarks/Pure.hs
@@ -92,6 +92,12 @@ benchmark kind fp = do
             , benchBSL $ nf (BL.concatMap (BL.replicate 3)) bla
             , benchS   $ nf (L.concatMap (L.replicate 3 . (:[]))) sa
             ]
+        , bgroup "compareText"
+            [ benchT   $ nf (ta <) ta  -- comparing 2 equal strings is the worst-case
+            , benchTL  $ nf (tla <) tla
+            , benchBS  $ nf (bsa <) bsa
+            , benchBSL $ nf (bla <) bla
+            ]
         , bgroup "decode"
             [ benchT   $ nf T.decodeUtf8 bsa
             , benchTL  $ nf TL.decodeUtf8 bla


### PR DESCRIPTION
we don't need to iterate over whole codepoints and decode them into Char's
it is ok to go word by word; this works also for 2-word codepoints
this saves ~10% of time, which is important for sorting/Map Text
benchmark:

```
before:

benchmarking Programs/Sort/Text
time                 591.7 ms   (577.7 ms .. 600.9 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 594.2 ms   (591.8 ms .. 595.8 ms)
std dev              2.352 ms   (0.0 s .. 2.713 ms)
variance introduced by outliers: 19% (moderately inflated)

after:

benchmarking Programs/Sort/Text
time                 531.2 ms   (527.8 ms .. 533.7 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 533.2 ms   (532.3 ms .. 533.7 ms)
std dev              855.6 μs   (0.0 s .. 857.6 μs)
variance introduced by outliers: 19% (moderately inflated)
```