### PR TITLE
Document that Data.Text.IO throws on decoding failure

### DIFF
--- a/Data/Text/IO.hs
+++ b/Data/Text/IO.hs
@@ -336,3 +336,7 @@ putStrLn = hPutStrLn stdout
 -- >
 -- > putStr_Utf16LE :: Text -> IO ()
 -- > putStr_Utf16LE t = B.putStr (encodeUtf16LE t)
+--
+-- If transcoding fails, an exception is thrown. If this behavior is
+-- undesired, will have to perform the transcoding yourself, likewise
+-- by using functions from "Data.ByteString" and "Data.Text.Encoding".


### PR DESCRIPTION
This not being documented has bitten me in the past, causing downtime.