### PR TITLE
Remove INLINE Pragma on indices

### DIFF
--- a/Data/Text/Internal/Search.hs
+++ b/Data/Text/Internal/Search.hs
@@ -86,4 +86,3 @@ indices _needle@(Text narr noff nlen) _haystack@(Text harr hoff hlen)
         where loop !i | i >= hlen     = []
                       | hindex i == c = i : loop (i+1)
                       | otherwise     = loop (i+1)
-{-# INLINE indices #-}


### PR DESCRIPTION
[For context, here is a recent reddit discussion about a program that runs faster with optimizations disabled.](https://www.reddit.com/r/haskell/comments/7yh8ar/i_wrote_a_program_that_runs_about_10_times_faster/).

This is caused by an interaction between the `INLINE` pragma on indices and the `INLINE [1]` pragma on isInfixOf. For some reason this combination keeps `buildTable 0 0 (nlen-2)` from being floated out. The end result is buildTable being run in each iteration of scan resulting in some impressively slow searches.

There are other ways to solve this issue but indices doesn't participate in fusion anyway and this seems like it'd impact code readability the least.