### PR TITLE
Add configuration for Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+build: off
+
+platform:
+- x64
+
+before_build:
+- curl -ostack.zip -L https://www.stackage.org/stack/windows-x86_64
+- 7z x stack.zip stack.exe
+
+cache:
+- '%APPDATA%\stack'
+
+build_script:
+- stack init --force
+- stack setup --no-terminal > nul
+- stack build --only-snapshot --no-terminal --trace
+
+test_script:
+- echo "" | stack test --no-terminal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
 - stack build --only-snapshot --no-terminal --trace
 
 test_script:
-- echo "" | stack test --no-terminal
+- echo "" | stack test text:tests --no-terminal


### PR DESCRIPTION
This [currently fails](https://ci.appveyor.com/project/berdario/text/build/1.0.3)

```
  hGetContents_crash: [Failed]
ERROR: DeleteFile ".\\crashy4118467.txt": permission denied (The process cannot access the file because it is being used by another process.)
```


Not sure if this fails also on other Windows environments (I don't have a Windows machine here at the moment)