### PR TITLE
fix text-tests.cabal

### DIFF
--- a/tests/text-tests.cabal
+++ b/tests/text-tests.cabal
@@ -29,7 +29,6 @@ executable text-tests
   main-is: Tests.hs
 
   other-modules:
-    Tests.IO
     Tests.Properties
     Tests.Properties.Mul
     Tests.QuickCheckUtils


### PR DESCRIPTION
`text-tests` doesn't build because `Tests.IO` has module name `Main`
`Tests.IO` has a separate build target `text-tests-stdio` and it shouldn't be here
  
```
        File name does not match module name:
        Saw: ‘Main’
        Expected: ‘Tests.IO’

    4 | module Main
      |        ^^^^
```