### PR TITLE
Remove unused imports.

### DIFF
--- a/Data/Text/Internal/Builder.hs
+++ b/Data/Text/Internal/Builder.hs
@@ -59,7 +59,7 @@ module Data.Text.Internal.Builder
 
 import Control.Monad.ST (ST, runST)
 import Data.Monoid (Monoid(..))
-#if MIN_VERSION_base(4,9,0)
+#if !MIN_VERSION_base(4,11,0) && MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Text.Internal (Text(..))


### PR DESCRIPTION
Due to a bug in ghc, some unused imports do not yield warnings.
This commit will remove such unused imports in preparation for
the ghc bug fix (see https://ghc.haskell.org/trac/ghc/ticket/13064).