### PR TITLE
Add ForeignFunctionInterface flag for compilation

### DIFF
--- a/Data/Text/Array.hs
+++ b/Data/Text/Array.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, CPP, MagicHash, Rank2Types,
+{-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface, MagicHash, Rank2Types,
     RecordWildCards, UnboxedTuples, UnliftedFFITypes #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 -- |

--- a/Data/Text/Encoding.hs
+++ b/Data/Text/Encoding.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE BangPatterns, CPP, GeneralizedNewtypeDeriving, MagicHash,
-    UnliftedFFITypes #-}
+{-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface,
+    GeneralizedNewtypeDeriving, MagicHash, UnliftedFFITypes #-}
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif


### PR DESCRIPTION
I don't know if this is the right things to do, but I was trying to get this repository to compile by running
```
stack init
stack build
```
and I got errors of the form
```
/home/paul/src/haskell/text/tests/../Data/Text/Encoding.hs:522:9: error:
    parse error on input ‘import’
    |
522 | foreign import ccall unsafe "_hs_text_decode_utf8" c_decode_utf8
    |         ^^^^^^
```
from a couple of modules.

Adding the `ForeignFunctionInterface` extension to the `LANGAUGE` pragma at the top of those files made it work for me, just not sure it's the right thing for everyone's build configuration.