### PR TITLE
Implement liftTyped in the Lift Text instances

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -254,7 +254,7 @@ import GHC.Base (eqInt, neInt, gtInt, geInt, ltInt, leInt)
 import qualified GHC.Exts as Exts
 #endif
 import qualified Language.Haskell.TH.Lib as TH
-import Language.Haskell.TH.Syntax (Lift, lift)
+import qualified Language.Haskell.TH.Syntax as TH
 #if MIN_VERSION_base(4,7,0)
 import Text.Printf (PrintfArg, formatArg, formatString)
 #endif
@@ -428,8 +428,11 @@ instance Data Text where
 -- it preserves abstraction at the cost of inefficiency.
 --
 -- @since 1.2.4.0
-instance Lift Text where
+instance TH.Lift Text where
   lift = TH.appE (TH.varE 'pack) . TH.stringE . unpack
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = TH.unsafeTExpCoerce . TH.lift
+#endif
 
 #if MIN_VERSION_base(4,7,0)
 -- | Only defined for @base-4.7.0.0@ and later

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -248,7 +248,7 @@ import qualified GHC.Exts as Exts
 #endif
 import GHC.Prim (Addr#)
 import qualified Language.Haskell.TH.Lib as TH
-import Language.Haskell.TH.Syntax (Lift, lift)
+import qualified Language.Haskell.TH.Syntax as TH
 #if MIN_VERSION_base(4,7,0)
 import Text.Printf (PrintfArg, formatArg, formatString)
 #endif
@@ -413,8 +413,11 @@ instance Data Text where
 -- it preserves abstraction at the cost of inefficiency.
 --
 -- @since 1.2.4.0
-instance Lift Text where
+instance TH.Lift Text where
   lift = TH.appE (TH.varE 'pack) . TH.stringE . unpack
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped = TH.unsafeTExpCoerce . TH.lift
+#endif
 
 #if MIN_VERSION_base(4,7,0)
 -- | Only defined for @base-4.7.0.0@ and later


### PR DESCRIPTION
`template-haskell-2.16.0.0` adds a `liftTyped` method to `Lift`, which is like `lift` but returning `Q (TExp t)` instead of `Q Exp`. `liftTyped` does not have a default implementation in terms of `lift`, so it must be implemented explicitly in the `Lift Text` instances that `text` defines. The implementations I chose are based off of the general approach taken by `Language.Haskell.TH.Syntax`, such as in this example: https://gitlab.haskell.org/ghc/ghc/blob/4898df1cc25132dc9e2599d4fa4e1bbc9423cda5/libraries/template-haskell/Language/Haskell/TH/Syntax.hs#L716