### PR TITLE
Bump ghc-prim upper bound

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -160,7 +160,7 @@ library
     base             >= 4.3 && < 5,
     binary           >= 0.5 && < 0.9,
     deepseq          >= 1.1 && < 1.5,
-    ghc-prim         >= 0.2 && < 0.6,
+    ghc-prim         >= 0.2 && < 0.7,
     template-haskell >= 2.5 && < 2.17
 
   if flag(bytestring-builder)


### PR DESCRIPTION
GHC 8.10 uses ghc-prim-0.6.1 currently.