### PR TITLE
Allow building with template-haskell-2.17

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -161,7 +161,7 @@ library
     binary           >= 0.5 && < 0.9,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.6,
-    template-haskell >= 2.5 && < 2.17
+    template-haskell >= 2.5 && < 2.18
 
   if flag(bytestring-builder)
     build-depends: bytestring         >= 0.9    && < 0.10.4,


### PR DESCRIPTION
GHC HEAD is planning to bump `template-haskell`'s major version number to 2.17 soon (see
https://gitlab.haskell.org/ghc/ghc/issues/17645) to reflect the [Overloaded Quotations](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0246-overloaded-bracket.rst) proposal being implemented. Before this can happen, `text`'s upper version bounds on `template-haskell` need to be bumped to allow `template-haskell-2.17`, as `text` is a boot library.

I have tested this change against GHC HEAD, and all test cases pass. I cannot forsee any interaction between the changes in the Overloaded Quotations proposal and the `text` library, as the only significant changes involve the types of quoted TH expressions and combinators in the `Language.Haskell.TH.Lib` library (neither of which `text` use).