### PR TITLE
Add support for ghc-bignum package

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -175,12 +175,16 @@ library
     ghc-options: -Werror
     cpp-options: -DASSERTS
 
-  if flag(integer-simple)
-    cpp-options: -DINTEGER_SIMPLE
-    build-depends: integer-simple >= 0.1 && < 0.5
-  else
-    cpp-options: -DINTEGER_GMP
-    build-depends: integer-gmp >= 0.2 && < 1.1
+  if impl(ghc >= 8.11)
+    build-depends: ghc-bignum
+
+  if impl(ghc < 8.11)
+    if flag(integer-simple)
+      cpp-options: -DINTEGER_SIMPLE
+      build-depends: integer-simple >= 0.1 && < 0.5
+    else
+      cpp-options: -DINTEGER_GMP
+      build-depends: integer-gmp >= 0.2 && < 1.1
 
   -- compiler specification
   default-language: Haskell2010
@@ -310,12 +314,16 @@ test-suite tests
   else
     build-depends: bytestring         >= 0.10.4
 
-  if flag(integer-simple)
-    cpp-options: -DINTEGER_SIMPLE
-    build-depends: integer-simple >= 0.1 && < 0.5
-  else
-    cpp-options: -DINTEGER_GMP
-    build-depends: integer-gmp >= 0.2
+  if impl(ghc >= 8.11)
+    build-depends: ghc-bignum
+
+  if impl(ghc < 8.11)
+    if flag(integer-simple)
+      cpp-options: -DINTEGER_SIMPLE
+      build-depends: integer-simple >= 0.1 && < 0.5
+    else
+      cpp-options: -DINTEGER_GMP
+      build-depends: integer-gmp >= 0.2
 
   default-language: Haskell2010
   default-extensions: NondecreasingIndentation


### PR DESCRIPTION
This patch adds support for ghc-bignum package in GHC 8.12: cf https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2231