### PR TITLE
Allow building with ghc-prim-0.7.*

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -160,7 +160,7 @@ library
     base             >= 4.3 && < 5,
     binary           >= 0.5 && < 0.9,
     deepseq          >= 1.1 && < 1.5,
-    ghc-prim         >= 0.2 && < 0.7,
+    ghc-prim         >= 0.2 && < 0.8,
     template-haskell >= 2.5 && < 2.18
 
   if flag(bytestring-builder)


### PR DESCRIPTION
This is needed for [GHC#18279](https://gitlab.haskell.org/ghc/ghc/issues/18279), which seeks to bump `ghc-prim`'s version number to 0.7.0.0 in order to accommodate `GHC.Tuple.Unit` being renamed to `GHC.Tuple.Solo`. Since `text` does not use `GHC.Tuple.Unit`, it is safe to simply bump `text`'s upper version bounds on `ghc-prim`.