### PR TITLE
Add Data.Text.Lazy.Builder.toText

### DIFF
--- a/src/Data/Text/Internal/Builder.hs
+++ b/src/Data/Text/Internal/Builder.hs
@@ -41,6 +41,7 @@ module Data.Text.Internal.Builder
      Builder
    , toLazyText
    , toLazyTextWith
+   , toText
 
      -- ** Constructing Builders
    , singleton
@@ -230,6 +231,10 @@ toLazyText = toLazyTextWith smallChunkSize
 toLazyTextWith :: Int -> Builder -> L.Text
 toLazyTextWith chunkSize m = L.fromChunks (runST $
   newBuffer chunkSize >>= runBuilder (m `append` flush) (const (return [])))
+
+-- | /O(n)./ Extract a strict @Text@ from a @Builder@.
+toText :: Builder -> Text
+toText = L.toStrict . toLazyText
 
 -- | /O(1)./ Pop the strict @Text@ we have constructed so far, if any,
 -- yielding a new chunk in the result lazy @Text@.

--- a/src/Data/Text/Lazy/Builder.hs
+++ b/src/Data/Text/Lazy/Builder.hs
@@ -43,6 +43,7 @@ module Data.Text.Lazy.Builder
      Builder
    , toLazyText
    , toLazyTextWith
+   , toText
 
      -- * Constructing Builders
    , singleton


### PR DESCRIPTION
This is a trivial composition, but it has been a recurring inconvenience for me for years. Particularly when I'm writing introductory tutorials, it is difficult to explain why among the three major types (strict text, lazy text, and builder) only five of the six possible conversion functions are given in the library.