### PR TITLE
Use SSE2 in the x86_64 C version of decodeLatin1

### DIFF
--- a/benchmarks/haskell/Benchmarks.hs
+++ b/benchmarks/haskell/Benchmarks.hs
@@ -43,6 +43,7 @@ main = do
         , env (DecodeUtf8.initEnv (tf "ascii.txt")) (DecodeUtf8.benchmark "ascii")
         , env (DecodeUtf8.initEnv (tf "russian.txt")) (DecodeUtf8.benchmark  "russian")
         , env (DecodeUtf8.initEnv (tf "japanese.txt")) (DecodeUtf8.benchmark "japanese")
+        , env (DecodeUtf8.initEnv (tf "ascii.txt")) (DecodeUtf8.benchmarkASCII)
         , EncodeUtf8.benchmark "επανάληψη 竺法蘭共譯"
         , env (Equality.initEnv (tf "japanese.txt")) Equality.benchmark
         , FileRead.benchmark (tf "russian.txt")

--- a/benchmarks/haskell/Benchmarks/DecodeUtf8.hs
+++ b/benchmarks/haskell/Benchmarks/DecodeUtf8.hs
@@ -17,6 +17,7 @@
 module Benchmarks.DecodeUtf8
     ( initEnv
     , benchmark
+    , benchmarkASCII
     ) where
 
 import Foreign.C.Types
@@ -65,6 +66,17 @@ benchmark kind ~(bs, lbs) =
         , bench "StrictStringUtf8Length" $ nf (length . U8.toString) bs
         , bench "LazyStringUtf8" $ nf U8.toString lbs
         , bench "LazyStringUtf8Length" $ nf (length . U8.toString) lbs
+        ]
+
+benchmarkASCII :: Env -> Benchmark
+benchmarkASCII ~(bs, lbs) =
+    bgroup "DecodeASCII"
+        [ C.bench "strict decodeUtf8" $ nf T.decodeUtf8 bs
+        , C.bench "strict decodeLatin1" $ nf T.decodeLatin1 bs
+        , C.bench "strict decodeASCII" $ nf T.decodeASCII bs
+        , C.bench "lazy decodeUtf8" $ nf TL.decodeUtf8 lbs
+        , C.bench "lazy decodeLatin1" $ nf TL.decodeLatin1 lbs
+        , C.bench "lazy decodeASCII" $ nf TL.decodeASCII lbs
         ]
 
 iconv :: B.ByteString -> IO CInt


### PR DESCRIPTION
Before (sorry for truncated lines):

```
benchmarking DecodeASCII/strict decodeLatin1
time                 28.60 ns   (28.53 ns .. 28.67
                     1.000 R²   (1.000 R² .. 1.000
mean                 28.60 ns   (28.50 ns .. 28.69
std dev              324.4 ps   (258.4 ps .. 426.7
variance introduced by outliers: 12% (moderately i

benchmarking DecodeASCII/lazy decodeLatin1
time                 39.73 ns   (39.42 ns .. 40.07
                     1.000 R²   (1.000 R² .. 1.000
mean                 39.56 ns   (39.46 ns .. 39.74
std dev              431.1 ps   (271.5 ps .. 699.6
variance introduced by outliers: 11% (moderately i
```

After:

```
benchmarking DecodeASCII/strict decodeLatin1
time                 21.71 ns   (21.67 ns .. 21.77 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 21.70 ns   (21.67 ns .. 21.74 ns)
std dev              114.6 ps   (90.46 ps .. 150.4 ps)

benchmarking DecodeASCII/lazy decodeLatin1
time                 32.80 ns   (32.75 ns .. 32.84 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 32.89 ns   (32.78 ns .. 33.39 ns)
std dev              660.6 ps   (137.1 ps .. 1.483 ns)
variance introduced by outliers: 29% (moderately inflated)
```