### PR TITLE
Introduce encodeASCII

### DIFF
--- a/benchmarks/haskell/Benchmarks.hs
+++ b/benchmarks/haskell/Benchmarks.hs
@@ -13,6 +13,7 @@ import qualified Benchmarks.Builder as Builder
 import qualified Benchmarks.Concat as Concat
 import qualified Benchmarks.DecodeUtf8 as DecodeUtf8
 import qualified Benchmarks.EncodeUtf8 as EncodeUtf8
+import qualified Benchmarks.EncodeASCII as EncodeASCII
 import qualified Benchmarks.Equality as Equality
 import qualified Benchmarks.FileRead as FileRead
 import qualified Benchmarks.FoldLines as FoldLines
@@ -36,37 +37,40 @@ main = do
     sink <- openFile "/dev/null" WriteMode
     hSetEncoding sink utf8
     defaultMain
-        [ Builder.benchmark
-        , Concat.benchmark
-        , env (DecodeUtf8.initEnv (tf "libya-chinese.html")) (DecodeUtf8.benchmark "html")
-        , env (DecodeUtf8.initEnv (tf "yiwiki.xml")) (DecodeUtf8.benchmark "xml")
-        , env (DecodeUtf8.initEnv (tf "ascii.txt")) (DecodeUtf8.benchmark "ascii")
-        , env (DecodeUtf8.initEnv (tf "russian.txt")) (DecodeUtf8.benchmark  "russian")
-        , env (DecodeUtf8.initEnv (tf "japanese.txt")) (DecodeUtf8.benchmark "japanese")
-        , EncodeUtf8.benchmark "επανάληψη 竺法蘭共譯"
-        , env (Equality.initEnv (tf "japanese.txt")) Equality.benchmark
-        , FileRead.benchmark (tf "russian.txt")
-        , FoldLines.benchmark (tf "russian.txt")
-        , env Mul.initEnv Mul.benchmark
-        , env (Pure.initEnv (tf "tiny.txt")) (Pure.benchmark "tiny")
-        , env (Pure.initEnv (tf "ascii-small.txt")) (Pure.benchmark "ascii-small")
-        , env (Pure.initEnv (tf "ascii.txt")) (Pure.benchmark "ascii")
-        , env (Pure.initEnv (tf "english.txt")) (Pure.benchmark "english")
-        , env (Pure.initEnv (tf "russian-small.txt")) (Pure.benchmark "russian")
-        , env (Pure.initEnv (tf "japanese.txt")) (Pure.benchmark "japanese")
-        , env (ReadNumbers.initEnv (tf "numbers.txt")) ReadNumbers.benchmark
-        , env (Replace.initEnv (tf "russian.txt")) (Replace.benchmark "принимая" "своем")
-        , env (Search.initEnv (tf "russian.txt")) (Search.benchmark "принимая")
-        , env (Stream.initEnv (tf "russian.txt")) Stream.benchmark
-        , env (WordFrequencies.initEnv (tf "russian.txt")) WordFrequencies.benchmark
-        , bgroup "Programs"
-            [ Programs.BigTable.benchmark sink
-            , Programs.Cut.benchmark (tf "russian.txt") sink 20 40
-            , Programs.Fold.benchmark (tf "russian.txt") sink
-            , Programs.Sort.benchmark (tf "russian.txt") sink
-            , Programs.StripTags.benchmark (tf "yiwiki.xml") sink
-            , Programs.Throughput.benchmark (tf "russian.txt") sink
-            ]
+        [ -- Builder.benchmark
+        -- , Concat.benchmark
+        -- , env (DecodeUtf8.initEnv (tf "libya-chinese.html")) (DecodeUtf8.benchmark "html")
+        -- , env (DecodeUtf8.initEnv (tf "yiwiki.xml")) (DecodeUtf8.benchmark "xml")
+        -- , env (DecodeUtf8.initEnv (tf "ascii.txt")) (DecodeUtf8.benchmark "ascii")
+        -- , env (DecodeUtf8.initEnv (tf "russian.txt")) (DecodeUtf8.benchmark  "russian")
+        -- , env (DecodeUtf8.initEnv (tf "japanese.txt")) (DecodeUtf8.benchmark "japanese")
+       -- , 
+        EncodeASCII.benchmark "Lorem ipsum dolor sit amet."
+        , EncodeUtf8.benchmark "ASCII" "Lorem ipsum dolor sit amet."
+        , EncodeUtf8.benchmark "non-ASCII"  "επανάληψη 竺法蘭共譯"
+        -- , env (Equality.initEnv (tf "japanese.txt")) Equality.benchmark
+        -- , FileRead.benchmark (tf "russian.txt")
+        -- , FoldLines.benchmark (tf "russian.txt")
+        -- , env Mul.initEnv Mul.benchmark
+        -- , env (Pure.initEnv (tf "tiny.txt")) (Pure.benchmark "tiny")
+        -- , env (Pure.initEnv (tf "ascii-small.txt")) (Pure.benchmark "ascii-small")
+        -- , env (Pure.initEnv (tf "ascii.txt")) (Pure.benchmark "ascii")
+        -- , env (Pure.initEnv (tf "english.txt")) (Pure.benchmark "english")
+        -- , env (Pure.initEnv (tf "russian-small.txt")) (Pure.benchmark "russian")
+        -- , env (Pure.initEnv (tf "japanese.txt")) (Pure.benchmark "japanese")
+        -- , env (ReadNumbers.initEnv (tf "numbers.txt")) ReadNumbers.benchmark
+        -- , env (Replace.initEnv (tf "russian.txt")) (Replace.benchmark "принимая" "своем")
+        -- , env (Search.initEnv (tf "russian.txt")) (Search.benchmark "принимая")
+        -- , env (Stream.initEnv (tf "russian.txt")) Stream.benchmark
+        -- , env (WordFrequencies.initEnv (tf "russian.txt")) WordFrequencies.benchmark
+        -- , bgroup "Programs"
+        --     [ Programs.BigTable.benchmark sink
+        --     , Programs.Cut.benchmark (tf "russian.txt") sink 20 40
+        --     , Programs.Fold.benchmark (tf "russian.txt") sink
+        --     , Programs.Sort.benchmark (tf "russian.txt") sink
+        --     , Programs.StripTags.benchmark (tf "yiwiki.xml") sink
+        --     , Programs.Throughput.benchmark (tf "russian.txt") sink
+        --     ]
         ]
     where
     -- Location of a test file

--- a/benchmarks/haskell/Benchmarks/EncodeASCII.hs
+++ b/benchmarks/haskell/Benchmarks/EncodeASCII.hs
@@ -1,12 +1,12 @@
--- | UTF-8 encode a text
+-- | ASCII encode a text
 --
 -- Tested in this benchmark:
 --
 -- * Replicating a string a number of times
 --
--- * UTF-8 encoding it
+-- * ASCII encoding it
 --
-module Benchmarks.EncodeUtf8
+module Benchmarks.EncodeASCII
     ( benchmark
     ) where
 
@@ -18,11 +18,11 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 
-benchmark :: String -> String -> Benchmark
-benchmark name string =
-    bgroup ("EncodeUtf8 (" <> name <> ")")
-        [ bench "Text"     $ whnf (B.length . T.encodeUtf8)   text
-        , bench "LazyText" $ whnf (BL.length . TL.encodeUtf8) lazyText
+benchmark :: String -> Benchmark
+benchmark string =
+    bgroup "EncodeASCII"
+        [ bench "Text"     $ whnf (B.length . T.encodeASCII)   text
+        , bench "LazyText" $ whnf (BL.length . TL.encodeASCII) lazyText
         ]
   where
     -- The string in different formats

--- a/src/Data/Text/Lazy/Encoding.hs
+++ b/src/Data/Text/Lazy/Encoding.hs
@@ -39,6 +39,7 @@ module Data.Text.Lazy.Encoding
     , decodeUtf32BEWith
 
     -- * Encoding Text to ByteStrings
+    , encodeASCII
     , encodeUtf8
     , encodeUtf16LE
     , encodeUtf16BE
@@ -160,6 +161,9 @@ encodeUtf8 lt@(Chunk t _) =
 encodeUtf8Builder :: Text -> B.Builder
 encodeUtf8Builder =
     foldrChunks (\c b -> TE.encodeUtf8Builder c `mappend` b) Data.Monoid.mempty
+
+encodeASCII :: Text -> B.ByteString
+encodeASCII = encodeUtf8
 
 -- | Encode text using UTF-8 encoding and escape the ASCII characters using
 -- a 'BP.BoundedPrim'.


### PR DESCRIPTION
Someone might want to use that for performance. Preliminary benchmark of a specialized encodeASCII vs encodeUtf8:

```
benchmarking EncodeASCII/Text
time                 310.1 μs   (309.0 μs .. 311.5 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 312.3 μs   (311.1 μs .. 314.0 μs)
std dev              4.574 μs   (3.482 μs .. 5.920 μs)

benchmarking EncodeUtf8 (ASCII)/Text
time                 893.0 μs   (851.0 μs .. 923.3 μs)
                     0.942 R²   (0.861 R² .. 0.988 R²)
mean                 1.324 ms   (1.185 ms .. 1.535 ms)
std dev              686.6 μs   (472.2 μs .. 957.7 μs)
```