### PR TITLE
Use SSE2 in the x86_64 C version of encodeUtf8

### DIFF
--- a/benchmarks/haskell/Benchmarks.hs
+++ b/benchmarks/haskell/Benchmarks.hs
@@ -43,7 +43,8 @@ main = do
         , env (DecodeUtf8.initEnv (tf "ascii.txt")) (DecodeUtf8.benchmark "ascii")
         , env (DecodeUtf8.initEnv (tf "russian.txt")) (DecodeUtf8.benchmark  "russian")
         , env (DecodeUtf8.initEnv (tf "japanese.txt")) (DecodeUtf8.benchmark "japanese")
-        , EncodeUtf8.benchmark "επανάληψη 竺法蘭共譯"
+        , EncodeUtf8.benchmark "non-ASCII" "επανάληψη 竺法蘭共譯"
+        , EncodeUtf8.benchmark "ASCII" "lorem ipsum"
         , env (Equality.initEnv (tf "japanese.txt")) Equality.benchmark
         , FileRead.benchmark (tf "russian.txt")
         , FoldLines.benchmark (tf "russian.txt")

--- a/benchmarks/haskell/Benchmarks/EncodeUtf8.hs
+++ b/benchmarks/haskell/Benchmarks/EncodeUtf8.hs
@@ -18,11 +18,11 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 
-benchmark :: String -> Benchmark
-benchmark string =
+benchmark :: String -> String -> Benchmark
+benchmark name string =
     bgroup "EncodeUtf8"
-        [ bench "Text"     $ whnf (B.length . T.encodeUtf8)   text
-        , bench "LazyText" $ whnf (BL.length . TL.encodeUtf8) lazyText
+        [ bench ("Text (" ++ name ++ ")")     $ whnf (B.length . T.encodeUtf8)   text
+        , bench ("LazyText (" ++ name ++ ")") $ whnf (BL.length . TL.encodeUtf8) lazyText
         ]
   where
     -- The string in different formats

--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -9,6 +9,10 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#if defined(__x86_64__)
+#include <xmmintrin.h>
+#include <emmintrin.h>
+#endif
 #include "text_cbits.h"
 
 void _hs_text_memcpy(void *dest, size_t doff, const void *src, size_t soff,
@@ -237,29 +241,36 @@ _hs_text_encode_utf8(uint8_t **destp, const uint16_t *src, size_t srcoff,
 
  ascii:
 #if defined(__x86_64__)
-  while (srcend - src >= 4) {
-    uint64_t w = *((uint64_t *) src);
+  while (srcend - src >= 8) {
+    union { uint64_t halves[2]; __m128i whole; } eight_chars;
+    eight_chars.whole = _mm_loadu_si128((__m128i *) src);
 
+    const uint64_t w = eight_chars.halves[0];
     if (w & 0xFF80FF80FF80FF80ULL) {
       if (!(w & 0x000000000000FF80ULL)) {
-	*dest++ = w & 0xFFFF;
-	src++;
-	if (!(w & 0x00000000FF800000ULL)) {
-	  *dest++ = (w >> 16) & 0xFFFF;
-	  src++;
-	  if (!(w & 0x0000FF8000000000ULL)) {
-	    *dest++ = (w >> 32) & 0xFFFF;
-	    src++;
-	  }
-	}
+        *dest++ = w & 0xFFFF;
+        src++;
+        if (!(w & 0x00000000FF800000ULL)) {
+          *dest++ = (w >> 16) & 0xFFFF;
+          src++;
+          if (!(w & 0x0000FF8000000000ULL)) {
+            *dest++ = (w >> 32) & 0xFFFF;
+            src++;
+          }
+        }
       }
       break;
     }
-    *dest++ = w & 0xFFFF;
-    *dest++ = (w >> 16) & 0xFFFF;
-    *dest++ = (w >> 32) & 0xFFFF;
-    *dest++ = w >> 48;
-    src += 4;
+
+    if (eight_chars.halves[1] & 0xFF80FF80FF80FF80ULL) {
+      break;
+    }
+
+    const __m128i eight_ascii_chars = _mm_packus_epi16(eight_chars.whole, eight_chars.whole);
+    _mm_storel_epi64((__m128i *)dest, eight_ascii_chars);
+
+    dest += 8;
+    src += 8;
   }
 #endif
 


### PR DESCRIPTION
Instead of introducing a specialized `encodeASCII` (https://github.com/haskell/text/pull/299) I managed to accelerate `encodeUtf8` for ASCII input without slowing it down for non-ASCII.

Before:

```
benchmarking EncodeUtf8/Text (non-ASCII)
time                 2.312 ms   (2.305 ms .. 2.317 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.340 ms   (2.331 ms .. 2.352 ms)
std dev              33.32 μs   (25.96 μs .. 40.96 μs)

benchmarking EncodeUtf8/Text (ASCII)
time                 295.6 μs   (294.6 μs .. 296.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 296.8 μs   (295.7 μs .. 298.8 μs)
std dev              4.785 μs   (2.933 μs .. 7.602 μs)

```

After:

```
benchmarking EncodeUtf8/Text (non-ASCII)
time                 2.321 ms   (2.308 ms .. 2.343 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 2.353 ms   (2.340 ms .. 2.381 ms)
std dev              66.32 μs   (42.43 μs .. 109.9 μs)
variance introduced by outliers: 14% (moderately inflated)

benchmarking EncodeUtf8/Text (ASCII)
time                 136.8 μs   (136.1 μs .. 137.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 137.0 μs   (136.6 μs .. 137.7 μs)
std dev              1.771 μs   (1.307 μs .. 2.713 μs)
```