### PR TITLE
Add rewrite rule to unfuse (text . drop)

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1224,6 +1224,8 @@ drop n t@(Text arr off len)
     drop n t = unstream (S.drop n (stream t))
 "TEXT drop -> unfused" [1] forall n t.
     unstream (S.drop n (stream t)) = drop n t
+"TEXT take . drop -> unfused" [1] forall len off t.
+    unstream (S.take len (S.drop off (stream t))) = take len (drop off t)
   #-}
 
 -- | /O(n)/ 'dropEnd' @n@ @t@ returns the prefix remaining after


### PR DESCRIPTION
## Problem

While profiling some project, the following function turned out to be the largest bottleneck:

```haskell
{-# INLINE slice #-}
-- | Substring from @offset@ to @offset + len@
slice :: Int -> Int -> Text -> Text
slice offset len = T.take len . T.drop offset
```

The direct cause of this bottleneck is fusion. The original `take` and `drop` functions work by calculating a new offset and length. A new view of `Text` can be returned without copying the underlying array. However, the `slice` function is rewritten, and the streaming implementation unnecessarily copies the data. This makes it much slower and more memory consuming.

With `take` and `drop` being fast individually, putting them together should not lead to a substantial decrease in performance.

## Proposed solution

Add a rewrite rule that specifically rewrites `take len . drop offset` back to an unfused version, just like the `TEXT take -> unfused` and `TEXT drop -> unfused` do for their respective functions individually.

I would argue that a rewrite rule for this very specific pair of functions is justified because it represents the very common substring operation. Since I don't think it would be wise to add `substring` to the interface of `Data.Text`, optimizing its de facto implementation would be the next best thing.

## Benchmark

A project hosting a benchmark can be found at [Channable/haskell-string-slicing-benchmarks](https://github.com/channable/haskell-string-slicing-benchmarks). It benchmarks the original function, the rule added by this pull request and three other solutions. See [`Bench.hs`](https://github.com/channable/haskell-string-slicing-benchmarks/blob/main/bench/Bench.hs).

Below are the results of the benchmark that showed the most significant difference between fused and unfused:

<details>

<summary>Benchmark results for above mentioned slice</summary>


```
benchmarking long-5000-1000/naiveSlice
time                 258.8 μs   (257.7 μs .. 259.7 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 260.4 μs   (260.3 μs .. 260.5 μs)
std dev              340.3 ns   (284.6 ns .. 483.1 ns)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1380479.830 (1380478.707 .. 1380481.163)
  y                  2550.560   (2209.409 .. 2956.324)
```

</details>

<details>

<summary>Benchmark results when the rule of this PR is included</summary>

```
benchmarking long-5000-1000/sliceWithRule
time                 4.941 μs   (4.937 μs .. 4.945 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.941 μs   (4.938 μs .. 4.944 μs)
std dev              9.959 ns   (8.231 ns .. 12.75 ns)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              64.000     (63.980 .. 64.025)
  y                  2556.215   (2301.293 .. 2812.799)
```
</details>

That's a huge difference, both in runtime and memory.

## Open questions

- There are many more subject-to-fusion functions that do not need to create a copy (`last`, `tail`, `init`, `null` to name a few). Any pipeline involving only such functions might be better off not being fused. Could a different approach to fusion improve performance here?
- `take n . drop m` is very a common operation. Are there other common operations that would benefit from such rules?