### PR TITLE
Fix `readFile` leaking file descriptors in the presence of asynchronous exceptions

### DIFF
--- a/src/Data/Text/IO.hs
+++ b/src/Data/Text/IO.hs
@@ -84,7 +84,7 @@ import System.IO.Error (isEOFError)
 -- the file as a string.  The entire file is read strictly, as with
 -- 'getContents'.
 readFile :: FilePath -> IO Text
-readFile name = openFile name ReadMode >>= hGetContents
+readFile name = withFile name ReadMode hGetContents
 
 -- | Write a string to a file.  The file is truncated to zero length
 -- before writing begins.

--- a/src/Data/Text/Lazy/IO.hs
+++ b/src/Data/Text/Lazy/IO.hs
@@ -78,7 +78,10 @@ import System.IO.Unsafe (unsafeInterleaveIO)
 -- | Read a file and return its contents as a string.  The file is
 -- read lazily, as with 'getContents'.
 readFile :: FilePath -> IO Text
-readFile name = openFile name ReadMode >>= hGetContents
+readFile name =
+  E.mask $ \restore -> do
+    h <- openFile name ReadMode
+    restore (hGetContents h)
 
 -- | Write a string to a file.  The file is truncated to zero length
 -- before writing begins.


### PR DESCRIPTION
`readFile` leaks file descriptors in the presence of asynchronous exceptions. I confirmed that with [this test](https://gitlab.com/rdnz/readfile-test/-/blob/text-io/app/Main.hs). I would have applied the nice fix for `Data.Text.IO.readFile` to `Data.Text.Lazy.IO.readFile` too but it does not get along well with lazy IO because the file handle will immediately be closed before reading is done.