### PR TITLE
Use base-provided unsafe shifts

### DIFF
--- a/src/Data/Text/Internal/Unsafe/Shift.hs
+++ b/src/Data/Text/Internal/Unsafe/Shift.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if MIN_VERSION_base(4,5,0)
+-- base-4.5.0 is 7.4, default sigs introduced in 7.2
+{-# LANGUAGE DefaultSignatures #-}
+#endif
 {-# LANGUAGE MagicHash #-}
 
 -- |
@@ -20,9 +25,13 @@ module Data.Text.Internal.Unsafe.Shift
       UnsafeShift(..)
     ) where
 
--- import qualified Data.Bits as Bits
+#if MIN_VERSION_base(4,5,0)
+import qualified Data.Bits as Bits
+import Data.Word
+#else
 import GHC.Base
 import GHC.Word
+#endif
 
 -- | This is a workaround for poor optimisation in GHC 6.8.2.  It
 -- fails to notice constant-width shifts, and adds a test and branch
@@ -32,35 +41,54 @@ import GHC.Word
 -- greater than the size in bits of a machine Int#.
 class UnsafeShift a where
     shiftL :: a -> Int -> a
+#if MIN_VERSION_base(4,5,0)
+    {-# INLINE shiftL #-}
+    default shiftL :: Bits.Bits a => a -> Int -> a
+    shiftL = Bits.unsafeShiftL
+#endif
+
     shiftR :: a -> Int -> a
+#if MIN_VERSION_base(4,5,0)
+    {-# INLINE shiftR #-}
+    default shiftR :: Bits.Bits a => a -> Int -> a
+    shiftR = Bits.unsafeShiftR
+#endif
 
 instance UnsafeShift Word16 where
+#if !MIN_VERSION_base(4,5,0)
     {-# INLINE shiftL #-}
     shiftL (W16# x#) (I# i#) = W16# (narrow16Word# (x# `uncheckedShiftL#` i#))
 
     {-# INLINE shiftR #-}
     shiftR (W16# x#) (I# i#) = W16# (x# `uncheckedShiftRL#` i#)
+#endif
 
 instance UnsafeShift Word32 where
+#if !MIN_VERSION_base(4,5,0)
     {-# INLINE shiftL #-}
     shiftL (W32# x#) (I# i#) = W32# (narrow32Word# (x# `uncheckedShiftL#` i#))
 
     {-# INLINE shiftR #-}
     shiftR (W32# x#) (I# i#) = W32# (x# `uncheckedShiftRL#` i#)
+#endif
 
 instance UnsafeShift Word64 where
+#if !MIN_VERSION_base(4,5,0)
     {-# INLINE shiftL #-}
     shiftL (W64# x#) (I# i#) = W64# (x# `uncheckedShiftL64#` i#)
 
     {-# INLINE shiftR #-}
     shiftR (W64# x#) (I# i#) = W64# (x# `uncheckedShiftRL64#` i#)
+#endif
 
 instance UnsafeShift Int where
+#if !MIN_VERSION_base(4,5,0)
     {-# INLINE shiftL #-}
     shiftL (I# x#) (I# i#) = I# (x# `iShiftL#` i#)
 
     {-# INLINE shiftR #-}
     shiftR (I# x#) (I# i#) = I# (x# `iShiftRA#` i#)
+#endif
 
 {-
 instance UnsafeShift Integer where


### PR DESCRIPTION
This makes the 9.2 prim changes less invasive. If we don't care about de-optimizing ancient GHCs we can remove this module altogether.