### PR TITLE
Use unsafeWithForeignPtr when available

### DIFF
--- a/src/Data/Text/Foreign.hs
+++ b/src/Data/Text/Foreign.hs
@@ -42,10 +42,11 @@ import Control.Monad.ST (unsafeIOToST)
 import Data.ByteString.Unsafe (unsafePackCStringLen, unsafeUseAsCStringLen)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Text.Internal (Text(..), empty)
+import Data.Text.Internal.Functions (unsafeWithForeignPtr)
 import Data.Text.Unsafe (lengthWord16)
 import Data.Word (Word16)
 import Foreign.C.String (CStringLen)
-import Foreign.ForeignPtr (ForeignPtr, mallocForeignPtrArray, withForeignPtr)
+import Foreign.ForeignPtr (ForeignPtr, mallocForeignPtrArray)
 import Foreign.Marshal.Alloc (allocaBytes)
 import Foreign.Ptr (Ptr, castPtr, plusPtr)
 import Foreign.Storable (peek, poke)
@@ -150,7 +151,7 @@ useAsPtr t@(Text _arr _off len) action =
 asForeignPtr :: Text -> IO (ForeignPtr Word16, I16)
 asForeignPtr t@(Text _arr _off len) = do
   fp <- mallocForeignPtrArray len
-  withForeignPtr fp $ unsafeCopyToPtr t
+  unsafeWithForeignPtr fp $ unsafeCopyToPtr t
   return (fp, I16 len)
 
 -- | /O(n)/ Decode a C string with explicit length, which is assumed

--- a/src/Data/Text/Internal/ByteStringCompat.hs
+++ b/src/Data/Text/Internal/ByteStringCompat.hs
@@ -53,3 +53,4 @@ plusForeignPtr (ForeignPtr addr guts) (I# offset) = ForeignPtr (plusAddr# addr o
  #-}
 #endif
 #endif
+

--- a/src/Data/Text/Internal/Encoding/Fusion.hs
+++ b/src/Data/Text/Internal/Encoding/Fusion.hs
@@ -44,8 +44,9 @@ import Data.Text.Encoding.Error
 import Data.Text.Internal.Encoding.Fusion.Common
 import Data.Text.Internal.Unsafe.Char (unsafeChr, unsafeChr8, unsafeChr32)
 import Data.Text.Internal.Unsafe.Shift (shiftL, shiftR)
+import Data.Text.Internal.Functions (unsafeWithForeignPtr)
 import Data.Word (Word8, Word16, Word32)
-import Foreign.ForeignPtr (withForeignPtr, ForeignPtr)
+import Foreign.ForeignPtr (ForeignPtr)
 import Foreign.Storable (pokeByteOff)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Unsafe as B
@@ -177,13 +178,13 @@ unstream (Stream next s0 len) = unsafeDupablePerformIO $ do
           Yield x s'
               | off == n -> realloc fp n off s' x
               | otherwise -> do
-            withForeignPtr fp $ \p -> pokeByteOff p off x
+            unsafeWithForeignPtr fp $ \p -> pokeByteOff p off x
             loop n (off+1) s' fp
       {-# NOINLINE realloc #-}
       realloc fp n off s x = do
         let n' = n+n
         fp' <- copy0 fp n n'
-        withForeignPtr fp' $ \p -> pokeByteOff p off x
+        unsafeWithForeignPtr fp' $ \p -> pokeByteOff p off x
         loop n' (off+1) s fp'
       {-# NOINLINE trimUp #-}
       trimUp fp _ off = return $! mkBS fp off
@@ -194,8 +195,8 @@ unstream (Stream next s0 len) = unsafeDupablePerformIO $ do
 #endif
         do
           dest <- mallocByteString destLen
-          withForeignPtr src  $ \src'  ->
-              withForeignPtr dest $ \dest' ->
+          unsafeWithForeignPtr src  $ \src'  ->
+              unsafeWithForeignPtr dest $ \dest' ->
                   memcpy dest' src' (fromIntegral srcLen)
           return dest
 

--- a/src/Data/Text/Internal/Functions.hs
+++ b/src/Data/Text/Internal/Functions.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Module      : Data.Text.Internal.Functions
 -- Copyright   : 2010 Bryan O'Sullivan
@@ -15,8 +17,17 @@
 
 module Data.Text.Internal.Functions
     (
-      intersperse
+      intersperse,
+      unsafeWithForeignPtr
     ) where
+
+import Foreign.Ptr (Ptr)
+import Foreign.ForeignPtr (ForeignPtr)
+#if MIN_VERSION_base(4,15,0)
+import qualified GHC.ForeignPtr (unsafeWithForeignPtr)
+#else
+import qualified Foreign.ForeignPtr (withForeignPtr)
+#endif
 
 -- | A lazier version of Data.List.intersperse.  The other version
 -- causes space leaks!
@@ -27,3 +38,10 @@ intersperse sep (x:xs) = x : go xs
     go []     = []
     go (y:ys) = sep : y: go ys
 {-# INLINE intersperse #-}
+
+unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
+#if MIN_VERSION_base(4,15,0)
+unsafeWithForeignPtr = GHC.ForeignPtr.unsafeWithForeignPtr
+#else
+unsafeWithForeignPtr = Foreign.ForeignPtr.withForeignPtr
+#endif


### PR DESCRIPTION
It turns out that all uses of `withForeignPtr` can safely use
`unsafeWithForeignPtr`.

I believe that this should resolve the regression noted in
[GHC #19557](https://gitlab.haskell.org/ghc/ghc/-/issues/19557)
although I am still benchmarking
