### PR TITLE
Fix UTF-8 decoding of lazy bytestrings

### DIFF
--- a/src/Data/Text/Lazy/Encoding.hs
+++ b/src/Data/Text/Lazy/Encoding.hs
@@ -100,9 +100,13 @@ decodeUtf8With onErr (B.Chunk b0 bs0) =
         TE.Some t l f -> chunk t (go f l bs)
     go _ l _
       | S.null l  = empty
-      | otherwise = case onErr desc (Just (B.unsafeHead l)) of
-                      Nothing -> empty
-                      Just c  -> Chunk (T.singleton c) Empty
+      | otherwise =
+        let !t = T.pack (skipBytes l)
+            skipBytes = S.foldr (\x s' ->
+                  case onErr desc (Just x) of
+                    Just c -> c : s'
+                    Nothing -> s') [] in
+        Chunk t Empty
     desc = "Data.Text.Lazy.Encoding.decodeUtf8With: Invalid UTF-8 stream"
 decodeUtf8With _ _ = empty
 

--- a/tests/Tests/Regressions.hs
+++ b/tests/Tests/Regressions.hs
@@ -20,6 +20,7 @@ import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
 import qualified Data.Text.Array as TA
 import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding.Error as E
 import qualified Data.Text.Internal as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as LT
@@ -136,6 +137,13 @@ t301 = do
     original@(T.Text originalArr originalOff originalLen) = T.pack "1234567890"
     T.Text newArr _off _len = T.take 1 $ T.drop 1 original
 
+t330 :: IO ()
+t330 = do
+  let decodeL = LE.decodeUtf8With E.lenientDecode
+  assertEqual "The lenient decoding of lazy bytestrings should not depend on how they are chunked"
+    (decodeL (LB.fromChunks [B.pack [194], B.pack [97, 98, 99]]))
+    (decodeL (LB.fromChunks [B.pack [194, 97, 98, 99]]))
+
 tests :: F.TestTree
 tests = F.testGroup "Regressions"
     [ F.testCase "hGetContents_crash" hGetContents_crash
@@ -149,4 +157,5 @@ tests = F.testGroup "Regressions"
     , F.testCase "t280/fromString" t280_fromString
     , F.testCase "t280/singleton" t280_singleton
     , F.testCase "t301" t301
+    , F.testCase "t330" t330
     ]


### PR DESCRIPTION
Fixes #330.

I found another issue that's not yet fixed: both strict and lazy `decodeUtf8With` are actually memory unsafe if you use a bad `onErr` argument. We allocate a destination buffer with 2x the number of bytes from the original bytestrings, but by using an `onErr` function which replaces any invalid byte with a `Char` which is a surrogate pair in UTF-16, it possible to blow up the size taken by a `Text` to 4x. In practice, `onErr` is almost always `lenientDecode` though, so perhaps a better solution than allocating more memory is to either hide `decodeUtf8With` or clamp the range of `onErr`.