### PR TITLE
Fix developer mode

### DIFF
--- a/src/Data/Text/Internal.hs
+++ b/src/Data/Text/Internal.hs
@@ -68,10 +68,8 @@ text_ :: A.Array -> Int -> Int -> Text
 text_ arr off len =
 #if defined(ASSERTS)
   let c    = A.unsafeIndex arr off
-      alen = A.length arr
   in assert (len >= 0) .
      assert (off >= 0) .
-     assert (alen == 0 || len == 0 || off < alen) .
      assert (len == 0 || c < 0xDC00 || c > 0xDFFF) $
 #endif
      Text arr off len

--- a/src/Data/Text/Internal/Encoding/Utf8.hs
+++ b/src/Data/Text/Internal/Encoding/Utf8.hs
@@ -33,13 +33,6 @@ module Data.Text.Internal.Encoding.Utf8
     , validate4
     ) where
 
-#if defined(TEST_SUITE)
-# undef ASSERTS
-#endif
-
-#if defined(ASSERTS)
-import Control.Exception (assert)
-#endif
 import Data.Bits ((.&.))
 import Data.Text.Internal.Unsafe.Char (ord)
 import Data.Text.Internal.Unsafe.Shift (shiftR)
@@ -62,9 +55,9 @@ between x y z = x >= y && x <= z
 
 ord2 :: Char -> (Word8,Word8)
 ord2 c =
-#if defined(ASSERTS)
-    assert (n >= 0x80 && n <= 0x07ff)
-#endif
+    -- ord2 is used only in test suite to construct a deliberately invalid ByteString,
+    -- actually violating the assertion, so it is commented out
+    -- assert (n >= 0x80 && n <= 0x07ff)
     (x1,x2)
     where
       n  = ord c
@@ -73,9 +66,9 @@ ord2 c =
 
 ord3 :: Char -> (Word8,Word8,Word8)
 ord3 c =
-#if defined(ASSERTS)
-    assert (n >= 0x0800 && n <= 0xffff)
-#endif
+    -- ord3 is used only in test suite to construct a deliberately invalid ByteString,
+    -- actually violating the assertion, so it is commented out
+    -- assert (n >= 0x0800 && n <= 0xffff)
     (x1,x2,x3)
     where
       n  = ord c
@@ -85,9 +78,9 @@ ord3 c =
 
 ord4 :: Char -> (Word8,Word8,Word8,Word8)
 ord4 c =
-#if defined(ASSERTS)
-    assert (n >= 0x10000)
-#endif
+    -- ord4 is used only in test suite to construct a deliberately invalid ByteString,
+    -- actually violating the assertion, so it is commented out
+    -- assert (n >= 0x10000)
     (x1,x2,x3,x4)
     where
       n  = ord c

--- a/src/Data/Text/Internal/Fusion/Common.hs
+++ b/src/Data/Text/Internal/Fusion/Common.hs
@@ -322,6 +322,7 @@ compareLengthI (Stream next s0 len) n
     -- Note that @len@ tracks code units whereas we want to compare the length
     -- in code points. Specifically, a stream with hint @len@ may consist of
     -- anywhere from @len/2@ to @len@ code points.
+  | n < 0 = GT
   | Just r <- compareSize len n' = r
   | otherwise = loop_cmp 0 s0
     where

--- a/text.cabal
+++ b/text.cabal
@@ -160,8 +160,7 @@ library
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)
-    ghc-prof-options: -auto-all
-    ghc-options: -Werror
+    ghc-options: -fno-ignore-asserts
     cpp-options: -DASSERTS
 
   if impl(ghc >= 8.11)


### PR DESCRIPTION
`text` package has a special `developer` flag, which enables certain safety checks such as out-of-bounds assertions. It seems it was unused for a long time, because several tests fail when `developer` is enabled. 

I also took an opportunity to make structure of `Array` and `MArray` independent of `developer` mode. Otherwise one cannot, for instance, use a `developer` build of `text` with `aeson` or any other package, which looks into `Text` internals. The reason to store the length of an underlying `ByteArray` is gone long ago: `sizeOfByteArray#` used to round it to the word size, but since GHC 7.0 it's precise. 

There were also redundant asserts, duplicating `unsafeIndex` and `unsafeWrite`. I cleaned them so that `Data.Text.Array` does not have a conditional export list any longer.