### PR TITLE
Drop support of GHC < 8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -44,18 +44,6 @@ jobs:
             allow-failure: false
           - compiler: ghc-8.0.2
             allow-failure: false
-          - compiler: ghc-7.10.3
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            allow-failure: false
-          - compiler: ghc-7.2.2
-            allow-failure: false
-          - compiler: ghc-7.0.4
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/benchmarks/haskell/Benchmarks/Builder.hs
+++ b/benchmarks/haskell/Benchmarks/Builder.hs
@@ -12,9 +12,6 @@ module Benchmarks.Builder
 import Test.Tasty.Bench (Benchmark, bgroup, bench, nf)
 import Data.Binary.Builder as B
 import Data.ByteString.Char8 ()
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mconcat, mempty)
-#endif
 import qualified Data.ByteString.Builder as Blaze
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB

--- a/benchmarks/haskell/Benchmarks/FileRead.hs
+++ b/benchmarks/haskell/Benchmarks/FileRead.hs
@@ -11,9 +11,6 @@ module Benchmarks.FileRead
     ( benchmark
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-#endif
 import Test.Tasty.Bench (Benchmark, bgroup, bench, whnfIO)
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Lazy as LB

--- a/benchmarks/haskell/Benchmarks/Programs/BigTable.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/BigTable.hs
@@ -12,9 +12,6 @@ module Benchmarks.Programs.BigTable
     ) where
 
 import Test.Tasty.Bench (Benchmark, bench, whnfIO)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mconcat, mempty, mappend)
-#endif
 import Data.Text.Lazy.Builder (Builder, fromText, toLazyText)
 import Data.Text.Lazy.IO (hPutStr)
 import System.IO (Handle)

--- a/benchmarks/haskell/Benchmarks/Programs/Fold.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/Fold.hs
@@ -19,9 +19,6 @@ module Benchmarks.Programs.Fold
 
 import Data.List (foldl')
 import Data.List (intersperse)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mempty, mappend, mconcat)
-#endif
 import System.IO (Handle)
 import Test.Tasty.Bench (Benchmark, bench, whnfIO)
 import qualified Data.Text as T

--- a/benchmarks/haskell/Benchmarks/Programs/Sort.hs
+++ b/benchmarks/haskell/Benchmarks/Programs/Sort.hs
@@ -18,9 +18,6 @@ module Benchmarks.Programs.Sort
     ) where
 
 import Test.Tasty.Bench (Benchmark, bgroup, bench, whnfIO)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mconcat)
-#endif
 import System.IO (Handle)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL

--- a/benchmarks/haskell/Benchmarks/Pure.hs
+++ b/benchmarks/haskell/Benchmarks/Pure.hs
@@ -15,9 +15,6 @@ module Benchmarks.Pure
 import Control.DeepSeq (NFData (..))
 import Control.Exception (evaluate)
 import Test.Tasty.Bench (Benchmark, bgroup, bench, nf)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mappend, mempty)
-#endif
 import GHC.Base (Char (..), Int (..), chr#, ord#, (+#))
 import GHC.Generics (Generic)
 import GHC.Int (Int64)
@@ -304,14 +301,6 @@ benchmark kind ~Env{..} =
     g (I# i#) (C# c#) = (I# (i# +# 1#), C# (chr# (ord# c# +# i#)))
     len l _ = l + (1::Int)
     short = T.pack "short"
-
-#if !MIN_VERSION_bytestring(0,10,0)
-instance NFData BS.ByteString
-
-instance NFData BL.ByteString where
-    rnf BL.Empty        = ()
-    rnf (BL.Chunk _ ts) = rnf ts
-#endif
 
 data B where
     B :: NFData a => a -> B

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,3 @@
 packages: .
 tests: True
 benchmarks: True
-constraints: semigroups -text -hashable -unordered-containers

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1,19 +1,8 @@
 {-# LANGUAGE BangPatterns, CPP, MagicHash, Rank2Types, UnboxedTuples, TypeFamilies #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-#if __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
--- Using TemplateHaskell in text unconditionally is unacceptable, as
--- it's a GHC boot library. TemplateHaskellQuotes was added in 8.0, so
--- this would seem to be a problem. However, GHC's policy of only
--- needing to be able to compile itself from the last few releases
--- allows us to use full-fat TH on older versions, while using THQ for
--- GHC versions that may be used for bootstrapping.
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TemplateHaskellQuotes #-}
-#else
-{-# LANGUAGE TemplateHaskell #-}
-#endif
+{-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- Module      : Data.Text
@@ -226,9 +215,7 @@ import qualified Data.Text.Array as A
 import qualified Data.List as L
 import Data.Binary (Binary(get, put))
 import Data.Monoid (Monoid(..))
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..))
-#endif
 import Data.String (IsString(..))
 import qualified Data.Text.Internal.Fusion as S
 import qualified Data.Text.Internal.Fusion.Common as S
@@ -251,14 +238,10 @@ import qualified Data.Text.Lazy as L
 import Data.Int (Int64)
 #endif
 import GHC.Base (eqInt, neInt, gtInt, geInt, ltInt, leInt)
-#if MIN_VERSION_base(4,7,0)
 import qualified GHC.Exts as Exts
-#endif
 import qualified Language.Haskell.TH.Lib as TH
 import qualified Language.Haskell.TH.Syntax as TH
-#if MIN_VERSION_base(4,7,0)
 import Text.Printf (PrintfArg, formatArg, formatString)
-#endif
 
 -- $setup
 -- >>> import Data.Text
@@ -364,37 +347,23 @@ instance Ord Text where
 instance Read Text where
     readsPrec p str = [(pack x,y) | (x,y) <- readsPrec p str]
 
-#if MIN_VERSION_base(4,9,0)
--- | Non-orphan 'Semigroup' instance only defined for
--- @base-4.9.0.0@ and later; orphan instances for older GHCs are
--- provided by
--- the [semigroups](http://hackage.haskell.org/package/semigroups)
--- package
---
--- @since 1.2.2.0
+-- | @since 1.2.2.0
 instance Semigroup Text where
     (<>) = append
-#endif
 
 instance Monoid Text where
     mempty  = empty
-#if MIN_VERSION_base(4,9,0)
-    mappend = (<>) -- future-proof definition
-#else
-    mappend = append
-#endif
+    mappend = (<>)
     mconcat = concat
 
 instance IsString Text where
     fromString = pack
 
-#if MIN_VERSION_base(4,7,0)
 -- | @since 1.2.0.0
 instance Exts.IsList Text where
     type Item Text = Char
     fromList       = pack
     toList         = unpack
-#endif
 
 instance NFData Text where rnf !_ = ()
 
@@ -442,13 +411,9 @@ instance TH.Lift Text where
   liftTyped = TH.unsafeTExpCoerce . TH.lift
 #endif
 
-#if MIN_VERSION_base(4,7,0)
--- | Only defined for @base-4.7.0.0@ and later
---
--- @since 1.2.2.0
+-- | @since 1.2.2.0
 instance PrintfArg Text where
   formatArg txt = formatString $ unpack txt
-#endif
 
 packConstr :: Constr
 packConstr = mkConstr textDataType "pack" [] Prefix

--- a/src/Data/Text/Array.hs
+++ b/src/Data/Text/Array.hs
@@ -42,6 +42,7 @@ module Data.Text.Array
 
 #if defined(ASSERTS)
 import Control.Exception (assert)
+import GHC.Base (sizeofByteArray#, sizeofMutableByteArray#)
 #endif
 import Control.Monad.ST.Unsafe (unsafeIOToST)
 import Data.Bits ((.&.), xor)
@@ -50,7 +51,7 @@ import Data.Text.Internal.Unsafe.Shift (shiftL, shiftR)
 import Foreign.C.Types (CInt(CInt), CSize(CSize))
 import GHC.Base (ByteArray#, MutableByteArray#, Int(..),
                  indexWord16Array#, newByteArray#,
-                 unsafeFreezeByteArray#, writeWord16Array#, sizeofByteArray#, sizeofMutableByteArray#)
+                 unsafeFreezeByteArray#, writeWord16Array#)
 import GHC.ST (ST(..), runST)
 import GHC.Word (Word16(..))
 import Prelude hiding (length, read)

--- a/src/Data/Text/Array.hs
+++ b/src/Data/Text/Array.hs
@@ -43,19 +43,11 @@ module Data.Text.Array
 #if defined(ASSERTS)
 import Control.Exception (assert)
 #endif
-#if MIN_VERSION_base(4,4,0)
 import Control.Monad.ST.Unsafe (unsafeIOToST)
-#else
-import Control.Monad.ST (unsafeIOToST)
-#endif
 import Data.Bits ((.&.), xor)
 import Data.Text.Internal.Unsafe (inlinePerformIO)
 import Data.Text.Internal.Unsafe.Shift (shiftL, shiftR)
-#if MIN_VERSION_base(4,5,0)
 import Foreign.C.Types (CInt(CInt), CSize(CSize))
-#else
-import Foreign.C.Types (CInt, CSize)
-#endif
 import GHC.Base (ByteArray#, MutableByteArray#, Int(..),
                  indexWord16Array#, newByteArray#,
                  unsafeFreezeByteArray#, writeWord16Array#, sizeofByteArray#, sizeofMutableByteArray#)

--- a/src/Data/Text/Encoding.hs
+++ b/src/Data/Text/Encoding.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE BangPatterns, CPP, GeneralizedNewtypeDeriving, MagicHash,
     UnliftedFFITypes #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Module      : Data.Text.Encoding
 -- Copyright   : (c) 2009, 2010, 2011 Bryan O'Sullivan,
@@ -59,11 +57,7 @@ module Data.Text.Encoding
     , encodeUtf8BuilderEscaped
     ) where
 
-#if MIN_VERSION_base(4,4,0)
 import Control.Monad.ST.Unsafe (unsafeIOToST, unsafeSTToIO)
-#else
-import Control.Monad.ST (unsafeIOToST, unsafeSTToIO)
-#endif
 
 import Control.Exception (evaluate, try, throwIO, ErrorCall(ErrorCall))
 import Control.Monad.ST (runST)
@@ -79,11 +73,7 @@ import Data.Text.Internal.Unsafe.Shift (shiftR)
 import Data.Text.Show ()
 import Data.Text.Unsafe (unsafeDupablePerformIO)
 import Data.Word (Word8, Word32)
-#if MIN_VERSION_base(4,5,0)
 import Foreign.C.Types (CSize(CSize))
-#else
-import Foreign.C.Types (CSize)
-#endif
 import Foreign.Marshal.Utils (with)
 import Foreign.Ptr (Ptr, minusPtr, nullPtr, plusPtr)
 import Foreign.Storable (Storable, peek, poke)

--- a/src/Data/Text/Encoding/Error.hs
+++ b/src/Data/Text/Encoding/Error.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE CPP, DeriveDataTypeable #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Module      : Data.Text.Encoding.Error
 -- Copyright   : (c) Bryan O'Sullivan 2009

--- a/src/Data/Text/Foreign.hs
+++ b/src/Data/Text/Foreign.hs
@@ -34,11 +34,7 @@ module Data.Text.Foreign
 #if defined(ASSERTS)
 import Control.Exception (assert)
 #endif
-#if MIN_VERSION_base(4,4,0)
 import Control.Monad.ST.Unsafe (unsafeIOToST)
-#else
-import Control.Monad.ST (unsafeIOToST)
-#endif
 import Data.ByteString.Unsafe (unsafePackCStringLen, unsafeUseAsCStringLen)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Text.Internal (Text(..), empty)

--- a/src/Data/Text/IO.hs
+++ b/src/Data/Text/IO.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, RecordWildCards, ScopedTypeVariables #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Module      : Data.Text.IO
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan,

--- a/src/Data/Text/Internal.hs
+++ b/src/Data/Text/Internal.hs
@@ -20,10 +20,6 @@
 -- with the internals, as the functions here do just about nothing to
 -- preserve data invariants.  You have been warned!
 
-#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-#include "MachDeps.h"
-#endif
-
 module Data.Text.Internal
     (
     -- * Types
@@ -124,11 +120,11 @@ firstf _  Nothing      = Nothing
 -- | Checked multiplication.  Calls 'error' if the result would
 -- overflow.
 mul :: Int -> Int -> Int
-#if WORD_SIZE_IN_BITS == 64
-mul a b = fromIntegral $ fromIntegral a `mul64` fromIntegral b
-#else
-mul a b = fromIntegral $ fromIntegral a `mul32` fromIntegral b
-#endif
+mul a b
+  | finiteBitSize (0 :: Word) == 64
+  = fromIntegral $ fromIntegral a `mul64` fromIntegral b
+  | otherwise
+  = fromIntegral $ fromIntegral a `mul32` fromIntegral b
 {-# INLINE mul #-}
 infixl 7 `mul`
 

--- a/src/Data/Text/Internal/Builder.hs
+++ b/src/Data/Text/Internal/Builder.hs
@@ -59,7 +59,7 @@ module Data.Text.Internal.Builder
 
 import Control.Monad.ST (ST, runST)
 import Data.Monoid (Monoid(..))
-#if !MIN_VERSION_base(4,11,0) && MIN_VERSION_base(4,9,0)
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup(..))
 #endif
 import Data.Text.Internal (Text(..), safe)
@@ -92,20 +92,14 @@ newtype Builder = Builder {
                 -> ST s [S.Text]
    }
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Builder where
    (<>) = append
    {-# INLINE (<>) #-}
-#endif
 
 instance Monoid Builder where
    mempty  = empty
    {-# INLINE mempty #-}
-#if MIN_VERSION_base(4,9,0)
-   mappend = (<>) -- future-proof definition
-#else
-   mappend = append
-#endif
+   mappend = (<>)
    {-# INLINE mappend #-}
    mconcat = foldr mappend Data.Monoid.mempty
    {-# INLINE mconcat #-}

--- a/src/Data/Text/Internal/Builder/RealFloat/Functions.hs
+++ b/src/Data/Text/Internal/Builder/RealFloat/Functions.hs
@@ -15,9 +15,6 @@ module Data.Text.Internal.Builder.RealFloat.Functions
     ) where
 
 roundTo :: Int -> [Int] -> (Int,[Int])
-
-#if MIN_VERSION_base(4,6,0)
-
 roundTo d is =
   case f d True is of
     x@(0,_) -> x
@@ -36,22 +33,3 @@ roundTo d is =
        (c,ds) = f (n-1) (even i) xs
        i'     = c + i
   base = 10
-
-#else
-
-roundTo d is =
-  case f d is of
-    x@(0,_) -> x
-    (1,xs)  -> (1, 1:xs)
-    _       -> error "roundTo: bad Value"
- where
-  f n []     = (0, replicate n 0)
-  f 0 (x:_)  = (if x >= 5 then 1 else 0, [])
-  f n (i:xs)
-     | i' == 10  = (1,0:ds)
-     | otherwise = (0,i':ds)
-      where
-       (c,ds) = f (n-1) xs
-       i'     = c + i
-
-#endif

--- a/src/Data/Text/Internal/Unsafe.hs
+++ b/src/Data/Text/Internal/Unsafe.hs
@@ -22,24 +22,17 @@ module Data.Text.Internal.Unsafe
     ) where
 
 import GHC.ST (ST(..))
-#if defined(__GLASGOW_HASKELL__)
 import GHC.IO (IO(IO))
 import GHC.Base (realWorld#)
-#endif
-
 
 -- | Just like unsafePerformIO, but we inline it. Big performance gains as
 -- it exposes lots of things to further inlining. /Very unsafe/. In
 -- particular, you should do no memory allocation inside an
--- 'inlinePerformIO' block. On Hugs this is just @unsafePerformIO@.
+-- 'inlinePerformIO' block.
 --
 {-# INLINE inlinePerformIO #-}
 inlinePerformIO :: IO a -> a
-#if defined(__GLASGOW_HASKELL__)
 inlinePerformIO (IO m) = case m realWorld# of (# _, r #) -> r
-#else
-inlinePerformIO = unsafePerformIO
-#endif
 
 -- | Allow an 'ST' computation to be deferred lazily. When passed an
 -- action of type 'ST' @s@ @a@, the action will only be performed when

--- a/src/Data/Text/Internal/Unsafe/Shift.hs
+++ b/src/Data/Text/Internal/Unsafe/Shift.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if MIN_VERSION_base(4,5,0)
--- base-4.5.0 is 7.4, default sigs introduced in 7.2
 {-# LANGUAGE DefaultSignatures #-}
-#endif
 {-# LANGUAGE MagicHash #-}
 
 -- |
@@ -25,13 +22,8 @@ module Data.Text.Internal.Unsafe.Shift
       UnsafeShift(..)
     ) where
 
-#if MIN_VERSION_base(4,5,0)
 import qualified Data.Bits as Bits
 import Data.Word
-#else
-import GHC.Base
-import GHC.Word
-#endif
 
 -- | This is a workaround for poor optimisation in GHC 6.8.2.  It
 -- fails to notice constant-width shifts, and adds a test and branch
@@ -41,60 +33,16 @@ import GHC.Word
 -- greater than the size in bits of a machine Int#.
 class UnsafeShift a where
     shiftL :: a -> Int -> a
-#if MIN_VERSION_base(4,5,0)
     {-# INLINE shiftL #-}
     default shiftL :: Bits.Bits a => a -> Int -> a
     shiftL = Bits.unsafeShiftL
-#endif
 
     shiftR :: a -> Int -> a
-#if MIN_VERSION_base(4,5,0)
     {-# INLINE shiftR #-}
     default shiftR :: Bits.Bits a => a -> Int -> a
     shiftR = Bits.unsafeShiftR
-#endif
 
 instance UnsafeShift Word16 where
-#if !MIN_VERSION_base(4,5,0)
-    {-# INLINE shiftL #-}
-    shiftL (W16# x#) (I# i#) = W16# (narrow16Word# (x# `uncheckedShiftL#` i#))
-
-    {-# INLINE shiftR #-}
-    shiftR (W16# x#) (I# i#) = W16# (x# `uncheckedShiftRL#` i#)
-#endif
-
 instance UnsafeShift Word32 where
-#if !MIN_VERSION_base(4,5,0)
-    {-# INLINE shiftL #-}
-    shiftL (W32# x#) (I# i#) = W32# (narrow32Word# (x# `uncheckedShiftL#` i#))
-
-    {-# INLINE shiftR #-}
-    shiftR (W32# x#) (I# i#) = W32# (x# `uncheckedShiftRL#` i#)
-#endif
-
 instance UnsafeShift Word64 where
-#if !MIN_VERSION_base(4,5,0)
-    {-# INLINE shiftL #-}
-    shiftL (W64# x#) (I# i#) = W64# (x# `uncheckedShiftL64#` i#)
-
-    {-# INLINE shiftR #-}
-    shiftR (W64# x#) (I# i#) = W64# (x# `uncheckedShiftRL64#` i#)
-#endif
-
 instance UnsafeShift Int where
-#if !MIN_VERSION_base(4,5,0)
-    {-# INLINE shiftL #-}
-    shiftL (I# x#) (I# i#) = I# (x# `iShiftL#` i#)
-
-    {-# INLINE shiftR #-}
-    shiftR (I# x#) (I# i#) = I# (x# `iShiftRA#` i#)
-#endif
-
-{-
-instance UnsafeShift Integer where
-    {-# INLINE shiftL #-}
-    shiftL = Bits.shiftL
-
-    {-# INLINE shiftR #-}
-    shiftR = Bits.shiftR
--}

--- a/src/Data/Text/Lazy/Builder.hs
+++ b/src/Data/Text/Lazy/Builder.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, Rank2Types #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Data/Text/Lazy/Builder/Int.hs
+++ b/src/Data/Text/Lazy/Builder/Int.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE BangPatterns, CPP, MagicHash, RankNTypes, ScopedTypeVariables,
     UnboxedTuples #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- Module:      Data.Text.Lazy.Builder.Int
 -- Copyright:   (c) 2013 Bryan O'Sullivan
@@ -34,8 +32,6 @@ import Control.Monad.ST
 import Prelude hiding ((<>))
 #endif
 
-#ifdef  __GLASGOW_HASKELL__
-
 #if __GLASGOW_HASKELL__ >= 811
 
 import GHC.Num.Integer
@@ -55,8 +51,6 @@ import GHC.Integer ()
 # else
 # error "You need to use either GMP or integer-simple."
 # endif
-#endif
-
 #endif
 
 decimal :: Integral a => a -> Builder

--- a/src/Data/Text/Lazy/Builder/RealFloat.hs
+++ b/src/Data/Text/Lazy/Builder/RealFloat.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP, OverloadedStrings #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module:    Data.Text.Lazy.Builder.RealFloat

--- a/src/Data/Text/Lazy/Encoding.hs
+++ b/src/Data/Text/Lazy/Encoding.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns,CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Module      : Data.Text.Lazy.Encoding
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan

--- a/src/Data/Text/Lazy/IO.hs
+++ b/src/Data/Text/Lazy/IO.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, RecordWildCards #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Module      : Data.Text.Lazy.IO
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan,

--- a/src/Data/Text/Lazy/Read.hs
+++ b/src/Data/Text/Lazy/Read.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE OverloadedStrings, CPP #-}
-#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
-#elif __GLASGOW_HASKELL__ >= 702
-{-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module      : Data.Text.Lazy.Read

--- a/src/Data/Text/Read.hs
+++ b/src/Data/Text/Read.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE OverloadedStrings, UnboxedTuples, CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module      : Data.Text.Read

--- a/src/Data/Text/Show.hs
+++ b/src/Data/Text/Show.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE CPP, MagicHash #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-#if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
-#endif
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
 -- Module      : Data.Text.Show
@@ -28,11 +27,7 @@ import GHC.Prim (Addr#)
 import qualified Data.Text.Array as A
 import qualified Data.Text.Internal.Fusion.Common as S
 
-#if __GLASGOW_HASKELL__ >= 702
 import qualified GHC.CString as GHC
-#else
-import qualified GHC.Base as GHC
-#endif
 
 instance Show Text where
     showsPrec p ps r = showsPrec p (unpack ps) r

--- a/tests/Tests/Properties/Builder.hs
+++ b/tests/Tests/Properties/Builder.hs
@@ -7,9 +7,6 @@ module Tests.Properties.Builder
     ( testBuilder
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Word
 import Numeric (showEFloat, showFFloat, showGFloat, showHex)

--- a/tests/Tests/Properties/Instances.hs
+++ b/tests/Tests/Properties/Instances.hs
@@ -6,9 +6,6 @@ module Tests.Properties.Instances
     ( testInstances
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
 import Data.String (IsString(fromString))
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)

--- a/tests/Tests/QuickCheckUtils.hs
+++ b/tests/Tests/QuickCheckUtils.hs
@@ -35,9 +35,6 @@ module Tests.QuickCheckUtils
     , write_read
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-#endif
 import Control.Arrow (first, (***))
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Exception (bracket)
@@ -61,11 +58,6 @@ import qualified Data.Text.Internal.Lazy.Fusion as TLF
 import qualified Data.Text.Lazy as TL
 import qualified System.IO as IO
 
-#if !MIN_VERSION_base(4,4,0)
-import Data.Int (Int64)
-import Data.Word (Word, Word64)
-#endif
-
 genUnicode :: IsString a => Gen a
 genUnicode = fromString <$> string
 
@@ -80,24 +72,6 @@ instance Arbitrary I16 where
 instance Arbitrary B.ByteString where
     arbitrary     = B.pack `fmap` arbitrary
     shrink        = map B.pack . shrink . B.unpack
-
-#if !MIN_VERSION_base(4,4,0)
-instance Random Int64 where
-    randomR = integralRandomR
-    random  = randomR (minBound,maxBound)
-
-instance Random Word where
-    randomR = integralRandomR
-    random  = randomR (minBound,maxBound)
-
-instance Random Word8 where
-    randomR = integralRandomR
-    random  = randomR (minBound,maxBound)
-
-instance Random Word64 where
-    randomR = integralRandomR
-    random  = randomR (minBound,maxBound)
-#endif
 
 -- For tests that have O(n^2) running times or input sizes, resize
 -- their inputs to the square root of the originals.

--- a/text.cabal
+++ b/text.cabal
@@ -58,8 +58,7 @@ category:       Data, Text
 build-type:     Simple
 tested-with:    GHC==9.0.1,
                 GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4,
-                GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4,
-                GHC==7.6.3, GHC==7.4.2, GHC==7.2.2, GHC==7.0.4
+                GHC==8.2.2, GHC==8.0.2
 extra-source-files:
     -- scripts/CaseFolding.txt
     -- scripts/SpecialCasing.txt
@@ -69,13 +68,6 @@ extra-source-files:
     scripts/*.hs
     tests/literal-rule-test.sh
     tests/LiteralRuleTest.hs
-
-flag bytestring-builder
-  description:
-    Depend on the [bytestring-builder](https://hackage.haskell.org/package/bytestring-builder)
-    package for backwards compatibility.
-  default: False
-  manual: False
 
 flag developer
   description: operate in developer mode
@@ -146,17 +138,12 @@ library
 
   build-depends:
     array            >= 0.3 && < 0.6,
-    base             >= 4.3 && < 5,
+    base             >= 4.9 && < 5,
     binary           >= 0.5 && < 0.9,
+    bytestring       >= 0.10.4 && < 0.12,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.9,
     template-haskell >= 2.5 && < 2.19
-
-  if flag(bytestring-builder)
-    build-depends: bytestring         >= 0.9    && < 0.10.4,
-                   bytestring-builder >= 0.10.4.0.2 && < 0.11
-  else
-    build-depends: bytestring         >= 0.10.4 && < 0.12
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)
@@ -190,19 +177,13 @@ library
     Rank2Types
     RankNTypes
     RecordWildCards
+    Safe
     ScopedTypeVariables
+    TemplateHaskellQuotes
+    Trustworthy
     TypeFamilies
     UnboxedTuples
     UnliftedFFITypes
-
-  if impl(ghc >= 7.2)
-    other-extensions: Trustworthy
-  if impl(ghc >= 7.4)
-    other-extensions: Safe
-  if impl(ghc >= 8.0)
-    other-extensions: TemplateHaskellQuotes
-  else
-    other-extensions: TemplateHaskell
 
 source-repository head
   type:     git
@@ -264,8 +245,7 @@ benchmark text-benchmarks
 
   build-depends:  base,
                   binary,
-                  -- we need instance NFData ByteString
-                  bytestring >= 0.10,
+                  bytestring >= 0.10.4,
                   bytestring-lexing >= 0.5.0,
                   containers,
                   deepseq,
@@ -275,12 +255,6 @@ benchmark text-benchmarks
                   text,
                   transformers,
                   vector
-
-  if flag(bytestring-builder)
-    build-depends: bytestring         >= 0.9    && < 0.10.4,
-                   bytestring-builder >= 0.10.4
-  else
-    build-depends: bytestring         >= 0.10.4
 
   c-sources:      benchmarks/cbits-bench/time_iconv.c
   hs-source-dirs: benchmarks/haskell

--- a/text.cabal
+++ b/text.cabal
@@ -74,13 +74,6 @@ flag developer
   default: False
   manual: True
 
-flag integer-simple
-  description:
-    Use the [simple integer library](http://hackage.haskell.org/package/integer-simple)
-    instead of [integer-gmp](http://hackage.haskell.org/package/integer-gmp)
-  default: False
-  manual: False
-
 library
   c-sources:    cbits/cbits.c
   include-dirs: include
@@ -150,18 +143,6 @@ library
     ghc-options: -fno-ignore-asserts
     cpp-options: -DASSERTS
 
-  if impl(ghc >= 8.11)
-    build-depends: ghc-bignum
-
-  else
-    if flag(integer-simple)
-      cpp-options: -DINTEGER_SIMPLE
-      build-depends: integer-simple >= 0.1 && < 0.5
-    else
-      cpp-options: -DINTEGER_GMP
-      build-depends: integer-gmp >= 0.2 && < 1.1
-
-  -- compiler specification
   default-language: Haskell2010
   default-extensions:
     NondecreasingIndentation


### PR DESCRIPTION
As discussed at previous maintainers meetings. 
A utf8 journey would go smoother without worrying about ancient GHCs.

CC @chessai @emilypi 