### PR TITLE
[text-1.2] Fix redundant import 

### DIFF
--- a/src/Data/Text/Lazy/Encoding.hs
+++ b/src/Data/Text/Lazy/Encoding.hs
@@ -59,7 +59,6 @@ import qualified Data.ByteString.Builder.Extra as B (safeStrategy, toLazyByteStr
 import qualified Data.ByteString.Builder.Prim as BP
 import qualified Data.ByteString.Lazy as B
 import qualified Data.ByteString.Lazy.Internal as B
-import qualified Data.ByteString.Unsafe as B
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Internal.Lazy.Encoding.Fusion as E


### PR DESCRIPTION
Fixes:
```
libraries/text/src/Data/Text/Lazy/Encoding.hs:62:1: error: [-Wunused-imports, -Werror=unused-imports]
    The qualified import of ‘Data.ByteString.Unsafe’ is redundant
      except perhaps to import instances from ‘Data.ByteString.Unsafe’
    To import instances alone, use: import Data.ByteString.Unsafe()
   |
62 | import qualified Data.ByteString.Unsafe as B
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```