### PR TITLE
Use copyToPointer in encodeUtf8Builder

### DIFF
--- a/benchmarks/haskell/Benchmarks/EncodeUtf8.hs
+++ b/benchmarks/haskell/Benchmarks/EncodeUtf8.hs
@@ -10,8 +10,10 @@ module Benchmarks.EncodeUtf8
     ( benchmark
     ) where
 
-import Test.Tasty.Bench (Benchmark, bgroup, bench, whnf)
+import Test.Tasty.Bench (Benchmark, bgroup, bench, nf, whnf)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Builder.Prim as BP
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -23,6 +25,8 @@ benchmark name string =
     bgroup name
         [ bench "Text"     $ whnf (B.length . T.encodeUtf8)   text
         , bench "LazyText" $ whnf (BL.length . TL.encodeUtf8) lazyText
+        , bench "Text/encodeUtf8Builder" $ nf (B.toLazyByteString . T.encodeUtf8Builder) text
+        , bench "Text/encodeUtf8BuilderEscaped" $ nf (B.toLazyByteString . T.encodeUtf8BuilderEscaped (BP.liftFixedToBounded BP.word8)) text
         ]
   where
     -- The string in different formats


### PR DESCRIPTION
Instead of copying each character separately by using `encodeUtf8BuilderEscaped` we instead resort to memcpy to copy the bytes into the target buffer more efficiently.

This PR is based off similar functions in the ByteString package: 

https://github.com/haskell/bytestring/blob/ba3046d9f5bf5cac1246c39f519b8be7ac11f49c/Data/ByteString/Builder/Internal.hs#L832-L845

https://github.com/haskell/bytestring/blob/ba3046d9f5bf5cac1246c39f519b8be7ac11f49c/Data/ByteString/Builder/Internal.hs#L779-L796