### PR TITLE
Haskell-CI for 9.2-rc1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20210606
+# version: 0.13.20210901
 #
-# REGENDATA ("0.13.20210606",["github","--config=cabal.haskell-ci","text.cabal"])
+# REGENDATA ("0.13.20210901",["github","--config=cabal.haskell-ci","text.cabal"])
 #
 name: Haskell-CI
 on:
@@ -26,14 +26,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.0.20210821
+            compilerKind: ghc
+            compilerVersion: 9.2.0.20210821
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-8.10.7
             compilerKind: ghc
-            compilerVersion: 8.10.4
+            compilerVersion: 8.10.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
@@ -68,7 +73,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.14.1/x86_64-linux-ghcup-0.1.14.1 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.16.2/x86_64-linux-ghcup-0.1.16.2 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
           "$HOME/.ghcup/bin/ghcup" install cabal 3.4.0.0
@@ -92,7 +97,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -121,6 +126,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -177,6 +193,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(text)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/text.cabal
+++ b/text.cabal
@@ -45,9 +45,17 @@ maintainer:     Haskell Text Team <andrew.lelechenko@gmail.com>, Core Libraries 
 copyright:      2009-2011 Bryan O'Sullivan, 2008-2009 Tom Harper, 2021 Andrew Lelechenko
 category:       Data, Text
 build-type:     Simple
-tested-with:    GHC==9.0.1,
-                GHC==8.10.4, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4,
-                GHC==8.2.2, GHC==8.0.2
+tested-with:
+    GHC == 8.0.2
+    GHC == 8.2.2
+    GHC == 8.4.4
+    GHC == 8.6.5
+    GHC == 8.8.4
+    GHC == 8.10.7
+    GHC == 9.0.1
+    GHC == 9.2.0.20210821
+    -- this is GHC-9.2-rc1
+
 extra-source-files:
     -- scripts/CaseFolding.txt
     -- scripts/SpecialCasing.txt


### PR DESCRIPTION
Test also GHC 9.2-rc1 under ubuntu.

Generated automatically with `haskell-ci` from `tested-with: GHC-9.2.0.20210821`.

Successful run at https://github.com/andreasabel/text/runs/3576075282?check_suite_focus=true