### PR TITLE
Undeprecate decodeASCII

### DIFF
--- a/benchmarks/haskell/Benchmarks/DecodeUtf8.hs
+++ b/benchmarks/haskell/Benchmarks/DecodeUtf8.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 -- | Test decoding of UTF-8
 --

--- a/src/Data/Text/Encoding.hs
+++ b/src/Data/Text/Encoding.hs
@@ -114,6 +114,10 @@ import GHC.Stack (HasCallStack)
 
 -- | Decode a 'ByteString' containing 7-bit ASCII
 -- encoded text.
+--
+-- This is a partial function: it checks that input does not contain
+-- anything except ASCII and copies buffer or throws an error otherwise.
+--
 decodeASCII :: ByteString -> Text
 decodeASCII bs = withBS bs $ \fp len -> if len == 0 then empty else runST $ do
   asciiPrefixLen <- fmap cSizeToInt $ unsafeIOToST $ unsafeWithForeignPtr fp $ \src ->
@@ -127,6 +131,10 @@ decodeASCII bs = withBS bs $ \fp len -> if len == 0 then empty else runST $ do
 --
 -- 'decodeLatin1' is semantically equivalent to
 --  @Data.Text.pack . Data.ByteString.Char8.unpack@
+--
+-- This is a total function. However, bear in mind that decoding Latin-1 (non-ASCII)
+-- characters to UTf-8 requires actual work and is not just buffer copying.
+--
 decodeLatin1 ::
 #if defined(ASSERTS)
   HasCallStack =>
@@ -374,6 +382,10 @@ streamDecodeUtf8With onErr = go mempty
 -- thrown that cannot be caught in pure code.  For more control over
 -- the handling of invalid data, use 'decodeUtf8'' or
 -- 'decodeUtf8With'.
+--
+-- This is a partial function: it checks that input is a well-formed
+-- UTF-8 sequence and copies buffer or throws an error otherwise.
+--
 decodeUtf8 :: ByteString -> Text
 decodeUtf8 = decodeUtf8With strictDecode
 {-# INLINE[0] decodeUtf8 #-}

--- a/src/Data/Text/Encoding.hs
+++ b/src/Data/Text/Encoding.hs
@@ -112,7 +112,7 @@ import GHC.Stack (HasCallStack)
 -- 'decodeUtf8With' allows the programmer to determine what to do on a
 -- decoding error.
 
--- | /Deprecated/.  Decode a 'ByteString' containing 7-bit ASCII
+-- | Decode a 'ByteString' containing 7-bit ASCII
 -- encoded text.
 decodeASCII :: ByteString -> Text
 decodeASCII bs = withBS bs $ \fp len -> if len == 0 then empty else runST $ do
@@ -122,7 +122,6 @@ decodeASCII bs = withBS bs $ \fp len -> if len == 0 then empty else runST $ do
   then let !(SBS.SBS arr) = SBS.toShort bs in
         return (Text (A.ByteArray arr) 0 len)
   else error $ "decodeASCII: detected non-ASCII codepoint at " ++ show asciiPrefixLen
-{-# DEPRECATED decodeASCII "Use decodeUtf8 instead" #-}
 
 -- | Decode a 'ByteString' containing Latin-1 (aka ISO-8859-1) encoded text.
 --

--- a/src/Data/Text/Lazy/Encoding.hs
+++ b/src/Data/Text/Lazy/Encoding.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE BangPatterns,CPP #-}
 {-# LANGUAGE Trustworthy #-}
 
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-
 -- |
 -- Module      : Data.Text.Lazy.Encoding
 -- Copyright   : (c) 2009, 2010 Bryan O'Sullivan
@@ -80,11 +78,10 @@ import Data.Text.Unsafe (unsafeDupablePerformIO)
 -- 'decodeUtf8With' allows the programmer to determine what to do on a
 -- decoding error.
 
--- | /Deprecated/.  Decode a 'ByteString' containing 7-bit ASCII
+-- | Decode a 'ByteString' containing 7-bit ASCII
 -- encoded text.
 decodeASCII :: B.ByteString -> Text
 decodeASCII = foldr (chunk . TE.decodeASCII) empty . B.toChunks
-{-# DEPRECATED decodeASCII "Use decodeUtf8 instead" #-}
 
 -- | Decode a 'ByteString' containing Latin-1 (aka ISO-8859-1) encoded text.
 decodeLatin1 :: B.ByteString -> Text

--- a/tests/Tests/Properties/Transcoding.hs
+++ b/tests/Tests/Properties/Transcoding.hs
@@ -1,19 +1,14 @@
 -- | Tests for encoding and decoding
 
 {-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-missing-signatures -fno-warn-unused-imports -fno-warn-deprecations #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Tests.Properties.Transcoding
     ( testTranscoding
     ) where
 
-import Control.Applicative ((<$>), (<*>))
 import Data.Bits ((.&.), shiftR)
 import Data.Char (chr, ord)
-import Data.Text.Encoding (encodeUtf8Builder, encodeUtf8BuilderEscaped)
-import Data.Text.Encoding.Error (UnicodeException)
-import Data.Text.Internal.Encoding.Utf8 (ord2, ord3, ord4)
 import Test.QuickCheck hiding ((.&.))
-import Test.QuickCheck.Property (Property(..))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 import Tests.QuickCheckUtils


### PR DESCRIPTION
With UTF8 representation there is no longer a reason to deprecate `decodeASCII`: all three `decodeASCII`, `decodeLatin1` and `decodeUtf8` have different trade offs. 

For example, `aeson` can benefit from using `decodeASCII`, see https://github.com/haskell/aeson/blob/06114272b1889f27a9833d01747b3372c71bcbc4/src/Data/Aeson/Parser/Internal.hs#L345-L349 and discussion at https://github.com/haskell/aeson/issues/893#issuecomment-974404169.