### PR TITLE
Make streamDecodeUtf8 stricter

### DIFF
--- a/src/Data/Text/Encoding.hs
+++ b/src/Data/Text/Encoding.hs
@@ -328,7 +328,7 @@ decodeUtf8With2 onErr bs1@(B.length -> len1) bs2@(B.length -> len2) = runST $ do
 -- | A stream oriented decoding result.
 --
 -- @since 1.0.0.0
-data Decoding = Some Text ByteString (ByteString -> Decoding)
+data Decoding = Some !Text !ByteString (ByteString -> Decoding)
 
 instance Show Decoding where
     showsPrec d (Some t bs _) = showParen (d > prec) $

--- a/tests/Tests/Properties/Transcoding.hs
+++ b/tests/Tests/Properties/Transcoding.hs
@@ -204,6 +204,11 @@ t_decode_with_error3' =
 t_decode_with_error4' =
   case E.streamDecodeUtf8With (\_ _ -> Just 'x') (B.pack [0xC2, 97, 97, 97]) of
     E.Some x _ _ -> x === "xaaa"
+t_decode_with_error5' = ioProperty $ do
+  ret <- Exception.try $ Exception.evaluate $ E.streamDecodeUtf8 (B.pack [0x81])
+  pure $ case ret of
+    Left (_ :: UnicodeException) -> True
+    Right{} -> False
 
 t_infix_concat bs1 text bs2 =
   forAll (Blind <$> genDecodeErr Replace) $ \(Blind onErr) ->
@@ -250,6 +255,7 @@ testTranscoding =
       testProperty "t_decode_with_error2'" t_decode_with_error2',
       testProperty "t_decode_with_error3'" t_decode_with_error3',
       testProperty "t_decode_with_error4'" t_decode_with_error4',
+      testProperty "t_decode_with_error5'" t_decode_with_error5',
       testProperty "t_infix_concat" t_infix_concat
     ]
   ]


### PR DESCRIPTION
Discovered this while testing `conduit` with `text-2.0`.

In `text-1.2.5.0`
```
> Data.Text.Encoding.streamDecodeUtf8 (Data.ByteString.pack [0x81]) `seq` ()
*** Exception: Cannot decode byte '\x81': Data.Text.Internal.Encoding.streamDecodeUtf8With: Invalid UTF-8 stream
```

But in `text-2.0`
```
> Data.Text.Encoding.streamDecodeUtf8 (Data.ByteString.pack [0x81]) `seq` ()
()
```

This can be fixed by forcing `txt` in 
https://github.com/haskell/text/blob/922d9cc7c537d55e3be2dba2343ef43e25493ace/src/Data/Text/Encoding.hs#L365-L369

But I decided to fix it in a more principled way by making fields of `Decoding` strict.