### PR TITLE
Faster fallback options when simdutf is not available

### DIFF
--- a/src/Data/Text/Internal/Encoding/Utf8.hs
+++ b/src/Data/Text/Internal/Encoding/Utf8.hs
@@ -35,6 +35,8 @@ module Data.Text.Internal.Encoding.Utf8
     , validate4
     -- * Naive decoding
     , DecoderResult(..)
+    , DecoderState(..)
+    , CodePoint(..)
     , utf8DecodeStart
     , utf8DecodeContinue
     ) where
@@ -269,18 +271,18 @@ data DecoderResult
 
 -- | @since 2.0
 utf8DecodeStart :: Word8 -> DecoderResult
-utf8DecodeStart w
+utf8DecodeStart !w
   | st == utf8AcceptState = Accept (chr (word8ToInt w))
   | st == utf8RejectState = Reject
   | otherwise             = Incomplete st (CodePoint cp)
   where
     cl@(ByteClass cl') = byteToClass w
     st = updateState cl utf8AcceptState
-    cp = word8ToInt $ (0xff `shiftR` word8ToInt cl') .&. w
+    cp = word8ToInt $ (0xff `unsafeShiftR` word8ToInt cl') .&. w
 
 -- | @since 2.0
 utf8DecodeContinue :: Word8 -> DecoderState -> CodePoint -> DecoderResult
-utf8DecodeContinue w st (CodePoint cp)
+utf8DecodeContinue !w !st (CodePoint !cp)
   | st' == utf8AcceptState = Accept (chr cp')
   | st' == utf8RejectState = Reject
   | otherwise              = Incomplete st' (CodePoint cp')


### PR DESCRIPTION
Currently when `simdutf` is disabled, we fallback to the slowest mode of operation: decode every byte into code points, then encode each code point back. This is wasteful and extremely (100x) slow. This PR provides two fallback options:

* If [`bytestring-0.11.2.0`](https://hackage.haskell.org/package/bytestring-0.11.2.0) is available, use [`Data.ByteString.isValidUtf8`](https://hackage.haskell.org/package/bytestring-0.11.2.0/docs/Data-ByteString.html#v:isValidUtf8).
* Otherwise use Haskell native implementation, but in validation-only mode, which is 10x faster than native decoding/encoding.