### PR TITLE
Special-case openbsd c++ libraries

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -95,7 +95,7 @@ library
         extra-libraries: stdc++-6 gcc_s_seh-1
       else
         extra-libraries: stdc++-6 gcc_s_dw2-1
-    elif os(darwin)
+    elif os(darwin) || os(freebsd)
       extra-libraries: c++
     elif os(openbsd)
       extra-libraries: c++ c++abi

--- a/text.cabal
+++ b/text.cabal
@@ -95,11 +95,12 @@ library
         extra-libraries: stdc++-6 gcc_s_seh-1
       else
         extra-libraries: stdc++-6 gcc_s_dw2-1
+    elif os(darwin)
+      extra-libraries: c++
+    elif os(openbsd)
+      extra-libraries: c++ c++abi
     else
-      if os(darwin)
-        extra-libraries: c++
-      else
-        extra-libraries: stdc++
+      extra-libraries: stdc++
 
   exposed-modules:
     Data.Text


### PR DESCRIPTION
They may be typical for clang-based systems, but I'm not sure what
that list is.

Fix #398

Related to https://gitlab.haskell.org/ghc/ghc/-/issues/20870