### PR TITLE
Use official Docker images for arm64

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,15 +1,25 @@
 kind: pipeline
-name: arm64
+name: arm64-ghc9.0
 platform: { os: linux, arch: arm64 }
 steps:
 - name: Test
-  image: buildpack-deps:focal
+  image: haskell:9.0
   commands:
-    - export LC_ALL=C.UTF-8
-    - apt-get update -y
-    - apt-get install -y ghc cabal-install
-    - cabal --version
-    - cabal new-update
+    - uname -a # check platform
+    - getconf LONG_BIT # check bitness
+    - cabal update
+    - cabal new-test
+---
+kind: pipeline
+name: arm64-ghc9.2
+platform: { os: linux, arch: arm64 }
+steps:
+- name: Test
+  image: haskell:9.2
+  commands:
+    - uname -a # check platform
+    - getconf LONG_BIT # check bitness
+    - cabal update
     - cabal new-test
 ---
 kind: pipeline

--- a/text.cabal
+++ b/text.cabal
@@ -106,6 +106,14 @@ library
   if os(windows) && impl(ghc >= 8.2 && < 8.4 || == 8.6.3 || == 8.10.1)
     build-depends: base < 0
 
+  -- GHC 8.10 has linking issues (probably TH-related) on ARM.
+  if (arch(aarch64) || arch(arm)) && impl(ghc == 8.10.*)
+    build-depends: base < 0
+
+  -- Subword primitives in GHC 9.2.1 are broken on ARM platforms.
+  if (arch(aarch64) || arch(arm)) && impl(ghc == 9.2.1)
+    build-depends: base < 0
+
   exposed-modules:
     Data.Text
     Data.Text.Array
@@ -236,10 +244,9 @@ test-suite tests
     template-haskell,
     text
 
-  -- Starting from 9.2 ghc library depends on parsec,
-  -- which causes circular dependency.
-  -- Plugin infrastructure does not work properly in 8.0.1 and 8.6.1
-  if impl(ghc >= 8.0.2 && < 8.6 || >= 8.6.2 && < 9.2)
+  -- Plugin infrastructure does not work properly in 8.0.1 and 8.6.1, and
+  -- ghc-9.2.1 library depends on parsec, which causes a circular dependency.
+  if impl(ghc >= 8.0.2 && < 8.6 || >= 8.6.2 && < 9.2 || >= 9.2.2)
     build-depends: tasty-inspection-testing
 
   default-language: Haskell2010


### PR DESCRIPTION
Expected to fail because of known issues with GHC 9.2.1.