### PR TITLE
allow on combinations of GHC 8.2 & Windows

### DIFF
--- a/cbits/measure_off.c
+++ b/cbits/measure_off.c
@@ -37,7 +37,7 @@
 
 #if defined(__x86_64__) && defined(COMPILER_SUPPORTS_AVX512)
 bool has_avx512_vl_bw() {
-#if __GNUC__ >= 6 || defined(__clang_major__)
+#if (__GNUC__ >= 7 || __GNUC__ == 6 && __GNUC_MINOR__ >= 3) || defined(__clang_major__)
   uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
   __get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx);
   // https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features

--- a/text.cabal
+++ b/text.cabal
@@ -102,8 +102,8 @@ library
   if flag(simdutf) && os(windows) && impl(ghc == 8.0.1 || >= 8.8 && < 8.10.5 || == 9.0.1)
     build-depends: base < 0
 
-  -- For GHC 8.2, 8.6.3 and 8.10.1 even TH + C crash Windows linker.
-  if os(windows) && impl(ghc >= 8.2 && < 8.4 || == 8.6.3 || == 8.10.1)
+  -- For GHC 8.6.3 and 8.10.1 even TH + C crash Windows linker.
+  if os(windows) && impl(ghc == 8.6.3 || == 8.10.1)
     build-depends: base < 0
 
   exposed-modules:


### PR DESCRIPTION
Combinations of GHC 8.2 & Windows were prohibited by #404. But text package can be built on the combinations with some CPP changes.

It seems that [`__get_cpuid_count` was introduced at GCC 6.3](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/ChangeLog;h=06ebfb1a548abc36a464ec713c33232c3c872baf;hb=91c632c88994dca583bcd94e39cd3eba1506ecfe).