### PR TITLE
Catch up OpenBSD extra-libraries to Clang 13

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -93,7 +93,7 @@ library
     if os(darwin) || os(freebsd)
       extra-libraries: c++
     elif os(openbsd)
-      extra-libraries: c++ c++abi
+      extra-libraries: c++ c++abi pthread
     else
       extra-libraries: stdc++
 


### PR DESCRIPTION
The system upgrade necessitates this list to be extended.
A better solution should be in cabal, but for now we have
no choice: https://github.com/haskell/cabal/issues/8007