### PR TITLE
Make Lift instances more efficient

### DIFF
--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -346,12 +346,9 @@ instance Data Text where
     _ -> error "Data.Text.Lazy.Text.gunfold"
   dataTypeOf _   = textDataType
 
--- | This instance has similar considerations to the 'Data' instance:
--- it preserves abstraction at the cost of inefficiency.
---
--- @since 1.2.4.0
+-- | @since 1.2.4.0
 instance TH.Lift Text where
-  lift = TH.appE (TH.varE 'pack) . TH.stringE . unpack
+  lift = TH.appE (TH.varE 'fromStrict) . TH.lift . toStrict
 #if MIN_VERSION_template_haskell(2,17,0)
   liftTyped = TH.unsafeCodeCoerce . TH.lift
 #elif MIN_VERSION_template_haskell(2,16,0)

--- a/tests/Tests/Lift.hs
+++ b/tests/Tests/Lift.hs
@@ -19,10 +19,16 @@ tests = testGroup "TH lifting Text"
   , testCase "strict0" $ assertEqual "strict0"
       $(lift ("f\0o\1o\2" :: S.Text))
       ("f\0o\1o\2" :: S.Text)
+  , testCase "strict-nihao" $ assertEqual "strict-nihao"
+      $(lift ("\20320\22909" :: S.Text))
+      ("\20320\22909" :: S.Text)
   , testCase "lazy" $ assertEqual "lazy"
       $(lift ("foo" :: L.Text))
       ("foo" :: L.Text)
   , testCase "lazy0" $ assertEqual "lazy0"
       $(lift ("f\0o\1o\2" :: L.Text))
       ("f\0o\1o\2" :: L.Text)
+  , testCase "lazy-nihao" $ assertEqual "lazy-nihao"
+      $(lift ("\20320\22909" :: L.Text))
+      ("\20320\22909" :: L.Text)
   ]


### PR DESCRIPTION
This patch allows the Lift instance to make use of the primitive bytes literals made available since template-haskell 2.16. 

It also adds some extra tests to make sure the instance works correctly with multi codepoint characters.

Let me know if you'd like some changes