### PR TITLE
Enable -fcheck-prim-bounds in developer mode

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -175,6 +175,8 @@ library
   if flag(developer)
     ghc-options: -fno-ignore-asserts
     cpp-options: -DASSERTS
+    if impl(ghc >= 9.2.2)
+      ghc-options: -fcheck-prim-bounds
 
   -- https://gitlab.haskell.org/ghc/ghc/-/issues/19900
   if os(windows)


### PR DESCRIPTION
GHC 9.2.2 features a new flag `-fcheck-prim-bounds`, which validates out-of-bounds access everywhere.
http://downloads.haskell.org/ghc/9.2.2/docs/html/users_guide/9.2.2-notes.html#compiler