### PR TITLE
Bump template-haskell upper bound

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -184,7 +184,7 @@ library
     bytestring       >= 0.10.4 && < 0.12,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.10,
-    template-haskell >= 2.5 && < 2.19
+    template-haskell >= 2.5 && < 2.20
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)


### PR DESCRIPTION
To accommodate GHC 9.4.