### PR TITLE
Unfold definition of Data.Text.Read.Reader

### DIFF
--- a/src/Data/Text/Lazy/Read.hs
+++ b/src/Data/Text/Lazy/Read.hs
@@ -36,7 +36,7 @@ import Data.Word (Word, Word8, Word16, Word32, Word64)
 
 -- | Read some text.  If the read succeeds, return its value and the
 -- remaining text, otherwise an error message.
-type Reader a = IReader Text a
+type Reader a = Text -> Either String (a, Text)
 type Parser = IParser Text
 
 -- | Read a decimal integer.  The input must begin with at least one

--- a/src/Data/Text/Read.hs
+++ b/src/Data/Text/Read.hs
@@ -33,7 +33,7 @@ import Data.Word (Word, Word8, Word16, Word32, Word64)
 
 -- | Read some text.  If the read succeeds, return its value and the
 -- remaining text, otherwise an error message.
-type Reader a = IReader Text a
+type Reader a = Text -> Either String (a, Text)
 type Parser a = IParser Text a
 
 -- | Read a decimal integer.  The input must begin with at least one


### PR DESCRIPTION
Closes #174. `Reader` is a synonym defined using `IReader` which is internal. But rather than export `IReader` this PR just removes mention of it. This only affects the documentation, removing an arguably unnecessary level of indirection.