### PR TITLE
Add foldr' and document the laziness of foldr

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -98,6 +98,7 @@ module Data.Text
     , foldl1
     , foldl1'
     , foldr
+    , foldr'
     , foldr1
 
     -- ** Special folds
@@ -992,6 +993,22 @@ foldl1' f t = S.foldl1' f (stream t)
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',
 -- reduces the 'Text' using the binary operator, from right to left.
+--
+-- If the binary operator is strict in its second argument, use 'foldr''
+-- instead.
+--
+-- 'foldr' is lazy like 'Data.List.foldr' for lists: evaluation actually
+-- traverses the 'Text' from left to right, only as far as it needs to.
+--
+-- For example, 'head' can be defined with /O(1)/ complexity using 'foldr':
+--
+-- @
+-- head :: Text -> Char
+-- head = foldr const (error "head empty")
+-- @
+--
+-- Searches from left to right with short-circuiting behavior can
+-- also be defined using 'foldr' (/e.g./, 'any', 'all', 'find', 'elem').
 foldr :: (Char -> a -> a) -> a -> Text -> a
 foldr f z t = S.foldr f z (stream t)
 {-# INLINE foldr #-}
@@ -1001,6 +1018,13 @@ foldr f z t = S.foldr f z (stream t)
 foldr1 :: HasCallStack => (Char -> Char -> Char) -> Text -> Char
 foldr1 f t = S.foldr1 f (stream t)
 {-# INLINE foldr1 #-}
+
+-- | /O(n)/ A strict version of 'foldr'.
+--
+-- 'foldr'' evaluates as a right-to-left traversal using constant stack space.
+foldr' :: (Char -> a -> a) -> a -> Text -> a
+foldr' f z t = S.foldl' (P.flip f) z (reverseStream t)
+{-# INLINE foldr' #-}
 
 -- -----------------------------------------------------------------------------
 -- ** Special folds

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -784,6 +784,16 @@ foldl1' f t = S.foldl1' f (stream t)
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',
 -- reduces the 'Text' using the binary operator, from right to left.
+--
+-- 'foldr' is lazy like 'Data.List.foldr' for lists: evaluation actually
+-- traverses the 'Text' from left to right, only as far as it needs to.
+--
+-- For example, 'head' can be defined with /O(1)/ complexity using 'foldr':
+--
+-- @
+-- head :: Text -> Char
+-- head = foldr const (error "head empty")
+-- @
 foldr :: (Char -> a -> a) -> a -> Text -> a
 foldr f z t = S.foldr f z (stream t)
 {-# INLINE foldr #-}


### PR DESCRIPTION
Unlike for lists, `foldr'` is a useful primitive for strict `Text` since we can easily iterate from either end. I discovered that while working on the other PR about `statefulSpan`, which uses `foldr'` in a test. It also turns out that `foldr` is lazier than one might expect, thanks to its implementation via a lazy stream, rather than an eager imperative loop, so that seemed worth documenting.

`foldr` and `foldr'` are thus mostly equivalent *denotationally*, ignoring the strictness differences, but *operationally*, `foldr` starts executing from the left, while `foldr'` starts from the right. `foldr` can short-circuit, whereas `foldr'` has to traverse the whole list, but can do so in a tighter loop.

- `foldr'` can also be defined for lazy `Text` but it's a little more involved.
- Dually, `foldl` can also be made lazier than it is currently, by starting from the right end (and this is arguably evidence that `foldr`'s aforementioned laziness is not that obvious from a certain perspective), but because that's an existing function I will need a more careful look to be sure I'm not breaking anything. Hence I'm postponing that for a future PR.

Note: this idea is already present in bytestring https://github.com/haskell/bytestring/blob/master/Data/ByteString.hs#L558