### PR TITLE
Stateful span

### DIFF
--- a/tests/Tests/QuickCheckUtils.hs
+++ b/tests/Tests/QuickCheckUtils.hs
@@ -12,6 +12,7 @@ module Tests.QuickCheckUtils
     , NotEmpty(..)
     , Sqrt(..)
     , SpacyString(..)
+    , SkewedBool(..)
 
     , Precision(..)
     , precision
@@ -277,3 +278,9 @@ newtype SpacyString = SpacyString { getSpacyString :: String }
 instance Arbitrary SpacyString where
   arbitrary = SpacyString `fmap` listOf arbitrarySpacyChar
   shrink (SpacyString xs) = SpacyString `fmap` shrink xs
+
+newtype SkewedBool = Skewed { getSkewed :: Bool }
+  deriving Show
+
+instance Arbitrary SkewedBool where
+  arbitrary = Skewed <$> frequency [(1, pure False), (5, pure True)]

--- a/text.cabal
+++ b/text.cabal
@@ -259,6 +259,7 @@ test-suite tests
     tasty-hunit,
     tasty-quickcheck,
     template-haskell,
+    transformers,
     text
 
   -- Plugin infrastructure does not work properly in 8.0.1 and 8.6.1, and


### PR DESCRIPTION
Closes #178 and #362  
Depends on PR #436

This PR implements `spanM` (span from the left) and `spanEndM`  (span from the right) for both strict and lazy `Text`.

`spanM` is a combination of `span` and `foldr`.

- `spanM`, as its name indicates, generalizes `span`, with a monadic predicate, of type `Char -> m Bool` rather than `Char -> Bool`.
- `spanM` generalizes a short-circuiting `foldr`, by also remembering the location where it stopped so you can easily resume with another search from there.
- `spanM` can also implement `foldl'` with the same space and time efficiency, by making the predicate always `True` and only using the state effect.

I argue these two functions pass the Fairbairn threshold as they provide the ability to safely move back and forth inside a `Text`. As mentioned in #178, this is currently not possible to do both efficiently and safely: either you keep track of an offset in code points, which then requires a redundant traversal to do `splitAt`, or you keep track of an offset in bytes, which is unsafe.

With `spanM` one can easily implement a `takeWhileM` (#362) by ignoring the remaining suffix. I'm not sure if its allocation would be optimized out already, but if not, I can generalize `spanM`` with some continuation-passing trick to do that in a future PR.
