### PR TITLE
Emphasize total functions in Data.Text.Encoding

### DIFF
--- a/src/Data/Text/Encoding.hs
+++ b/src/Data/Text/Encoding.hs
@@ -25,30 +25,38 @@ module Data.Text.Encoding
     (
     -- * Decoding ByteStrings to Text
     -- $strict
-      decodeASCII
-    , decodeLatin1
+
+    -- ** Total Functions #total#
+    -- $total
+      decodeLatin1
+    , decodeUtf8Lenient
+
+    -- *** Catchable failure
+    , decodeUtf8'
+
+    -- *** Controllable error handling
+    , decodeUtf8With
+    , decodeUtf16LEWith
+    , decodeUtf16BEWith
+    , decodeUtf32LEWith
+    , decodeUtf32BEWith
+
+    -- *** Stream oriented decoding
+    -- $stream
+    , streamDecodeUtf8With
+    , Decoding(..)
+
+    -- ** Partial Functions
+    -- $partial
+    , decodeASCII
     , decodeUtf8
     , decodeUtf16LE
     , decodeUtf16BE
     , decodeUtf32LE
     , decodeUtf32BE
 
-    -- ** Catchable failure
-    , decodeUtf8'
-
-    -- ** Controllable error handling
-    , decodeUtf8With
-    , decodeUtf8Lenient
-    , decodeUtf16LEWith
-    , decodeUtf16BEWith
-    , decodeUtf32LEWith
-    , decodeUtf32BEWith
-
-    -- ** Stream oriented decoding
-    -- $stream
+    -- *** Stream oriented decoding
     , streamDecodeUtf8
-    , streamDecodeUtf8With
-    , Decoding(..)
 
     -- * Encoding Text to ByteStrings
     , encodeUtf8
@@ -115,6 +123,17 @@ import Data.Text.Internal.Encoding.Utf8 (CodePoint(..))
 -- For instance, 'decodeUtf8' will throw an exception, but
 -- 'decodeUtf8With' allows the programmer to determine what to do on a
 -- decoding error.
+
+-- $total
+--
+-- These functions facilitate total decoding and should be preferred
+-- over their partial counterparts.
+
+-- $partial
+--
+-- These functions are partial and should only be used with great caution
+-- (preferably not at all). See "Data.Text.Encoding#g:total" for better
+-- solutions.
 
 -- | Decode a 'ByteString' containing 7-bit ASCII
 -- encoded text.

--- a/src/Data/Text/Lazy/Encoding.hs
+++ b/src/Data/Text/Lazy/Encoding.hs
@@ -19,23 +19,29 @@ module Data.Text.Lazy.Encoding
     (
     -- * Decoding ByteStrings to Text
     -- $strict
-      decodeASCII
-    , decodeLatin1
-    , decodeUtf8
-    , decodeUtf16LE
-    , decodeUtf16BE
-    , decodeUtf32LE
-    , decodeUtf32BE
 
-    -- ** Catchable failure
+    -- ** Total Functions #total#
+    -- $total
+      decodeLatin1
+
+    -- *** Catchable failure
     , decodeUtf8'
 
-    -- ** Controllable error handling
+    -- *** Controllable error handling
     , decodeUtf8With
     , decodeUtf16LEWith
     , decodeUtf16BEWith
     , decodeUtf32LEWith
     , decodeUtf32BEWith
+
+    -- ** Partial Functions
+    -- $partial
+    , decodeASCII
+    , decodeUtf8
+    , decodeUtf16LE
+    , decodeUtf16BE
+    , decodeUtf32LE
+    , decodeUtf32BE
 
     -- * Encoding Text to ByteStrings
     , encodeUtf8
@@ -77,6 +83,17 @@ import Data.Text.Unsafe (unsafeDupablePerformIO)
 -- For instance, 'decodeUtf8' will throw an exception, but
 -- 'decodeUtf8With' allows the programmer to determine what to do on a
 -- decoding error.
+
+-- $total
+--
+-- These functions facilitate total decoding and should be preferred
+-- over their partial counterparts.
+
+-- $partial
+--
+-- These functions are partial and should only be used with great caution
+-- (preferably not at all). See "Data.Text.Lazy.Encoding#g:total" for better
+-- solutions.
 
 -- | Decode a 'ByteString' containing 7-bit ASCII
 -- encoded text.


### PR DESCRIPTION
Resolves #248. The basic idea is to split total/partial functions into explicit sections, and place the total section first. Some comments/questions:

1. I am open to making the warnings on partial functions themselves louder e.g. changing `decodeUtf8`'s current text:

    > This is a partial function: it checks that input is a well-formed
     UTF-8 sequence and copies buffer or throws an error otherwise.

    to (up to bikeshedding):

    >  __WARNING__: This is a __partial__ function: it checks that input is a well-formed
     UTF-8 sequence and copies buffer or throws an error otherwise.
 
    I don't think the danger can really be overemphasized, given how destructive they have proven to be. And this way people using e.g. HLS can see them on hover even if they are not looking at the module's documentation. But I wanted to solicit feedback before becoming too opinionated.

1. Minor point, but is there a way to link anchors without the qualified module name showing up (e.g. either a 'local' anchor or supplying a custom name? That is, I linked to the total section with `See "Data.Text.Encoding#g:total" ...`, and this renders as:

    > See [Data.Text.Encoding](https://tbidne.github.io/text/Data-Text-Encoding.html#g:total) ...
    
    This is slightly annoying imo as the link text is not indicative of the actual location (specifically, the `total` anchor), though it does work, at least. I suppose one could supply a full hyperlink, but may this isn't a big deal in any case. [Here](https://haskell-haddock.readthedocsbe.io/en/latest/markup.html#anchors) are the haddock docs for reference.

1. Presumably we would want the same thing done to `Data.Text.Lazy.Encoding`. I will do this after the language is tentatively approved.

1. I noticed in the unmerged https://github.com/haskell/text/pull/318, there is a note about updating the changelog. I can do this after everything is settled.

The rendering can be seen [here](https://tbidne.github.io/text/Data-Text-Encoding.html).

Thanks!