### PR TITLE
Use system-cxx-std-lib virtual package where available

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -90,7 +90,9 @@ library
                  cbits/validate_utf8.cpp
     cxx-options: -std=c++17
     cpp-options: -DSIMDUTF
-    if os(darwin) || os(freebsd)
+    if impl(ghc >= 9.4)
+      build-depends: system-cxx-std-lib == 1.0
+    elif os(darwin) || os(freebsd)
       extra-libraries: c++
     elif os(openbsd)
       extra-libraries: c++ c++abi pthread


### PR DESCRIPTION
Starting with the 9.4 release, GHC provides `system-cxx-std-lib`, a
"virtual" package which can be used to reliably link against the
system's C++ standard library implementation.

See GHC #20010.