### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+### 2.0.1
+
+* Improve portability of C and C++ code.
+* [Make `Lift` instance more efficient](https://github.com/haskell/text/pull/413)
+* [Make `toCaseFold` idempotent](https://github.com/haskell/text/pull/402)
+* [Add `fromPtr0`](https://github.com/haskell/text/pull/423)
+* [Add `Data.Text.foldr'`](https://github.com/haskell/text/pull/436)
+* [Add `withCString`](https://github.com/haskell/text/pull/431)
+* [Add `spanM` and `spanEndM`](https://github.com/haskell/text/pull/437)
+
 ### 2.0
 
 * [Switch internal representation of text from UTF-16 to UTF-8](https://github.com/haskell/text/pull/365):

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1040,6 +1040,8 @@ foldr1 f t = S.foldr1 f (stream t)
 -- | /O(n)/ A strict version of 'foldr'.
 --
 -- 'foldr'' evaluates as a right-to-left traversal using constant stack space.
+--
+-- @since 2.0.1
 foldr' :: (Char -> a -> a) -> a -> Text -> a
 foldr' f z t = S.foldl' (P.flip f) z (reverseStream t)
 {-# INLINE foldr' #-}
@@ -1477,6 +1479,8 @@ break p = span (not . p)
 -- -- for all p :: Char -> Bool
 -- 'span' p = 'Data.Functor.Identity.runIdentity' . 'spanM' ('pure' . p)
 -- @
+--
+-- @since 2.0.1
 spanM :: Monad m => (Char -> m Bool) -> Text -> m (Text, Text)
 spanM p t@(Text arr off len) = go 0
   where
@@ -1498,6 +1502,8 @@ spanM p t@(Text arr off len) = go 0
 -- @
 -- 'spanEndM' p . 'reverse' = fmap ('Data.Bifunctor.bimap' 'reverse' 'reverse') . 'spanM' p
 -- @
+--
+-- @since 2.0.1
 spanEndM :: Monad m => (Char -> m Bool) -> Text -> m (Text, Text)
 spanEndM p t@(Text arr off len) = go (len-1)
   where

--- a/src/Data/Text/Foreign.hs
+++ b/src/Data/Text/Foreign.hs
@@ -79,6 +79,8 @@ fromPtr ptr (I8 len) = unsafeSTToIO $ do
 
 -- | /O(n)/ Create a new 'Text' from a 'Ptr' 'Word8' by copying the
 -- contents of the NUL-terminated array.
+--
+-- @since 2.0.1
 fromPtr0 :: Ptr Word8           -- ^ source array
          -> IO Text
 fromPtr0 ptr@(Ptr addr#) = fromPtr ptr (fromIntegral (addrLen addr#))

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -1336,6 +1336,8 @@ span p = break (not . p)
 -- -- for all p :: Char -> Bool
 -- 'span' p = 'Data.Functor.Identity.runIdentity' . 'spanM' ('pure' . p)
 -- @
+--
+-- @since 2.0.1
 spanM :: Monad m => (Char -> m Bool) -> Text -> m (Text, Text)
 spanM p t0 = go t0
   where
@@ -1356,6 +1358,8 @@ spanM p t0 = go t0
 -- @
 -- 'spanEndM' p . 'reverse' = fmap ('Data.Bifunctor.bimap' 'reverse' 'reverse') . 'spanM' p
 -- @
+--
+-- @since 2.0.1
 spanEndM :: Monad m => (Char -> m Bool) -> Text -> m (Text, Text)
 spanEndM p t0 = go t0
   where

--- a/text.cabal
+++ b/text.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           text
-version:        2.0
+version:        2.0.1
 
 homepage:       https://github.com/haskell/text
 bug-reports:    https://github.com/haskell/text/issues


### PR DESCRIPTION
As requested by GHC developers, we should release `text-2.0.1` fairly soon.