### PR TITLE
Add writeAtMost function to the export list.

### DIFF
--- a/src/Data/Text/Internal/Builder.hs
+++ b/src/Data/Text/Internal/Builder.hs
@@ -54,6 +54,7 @@ module Data.Text.Internal.Builder
      -- * Internal functions
    , append'
    , ensureFree
+   , writeAtMost
    , writeN
    ) where
 


### PR DESCRIPTION
This function gives a possibility to create a Builder with a length unknown initially. 
It is required for double-conversion to create Builder properly when it knows only max length of text but not the final.
Using writeN leads in this case to creating a Builder with max length discarding the actual length of the written buffer. 

The only question I have is if a shrink function should be used inside of
writeAtMost. I am asking because it seems that it only changes "used units" and "length left" but not the actual size of the freed buffer. That could lead to memory over-usage. 
On the other hand, using a shrinking function every time could waste CPU time.