### PR TITLE
Reduce code bloat for literal strings by avoiding RULES and inlining

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -237,7 +237,7 @@ import qualified Data.Text.Internal.Fusion.Common as S
 import Data.Text.Encoding (decodeUtf8', encodeUtf8)
 import Data.Text.Internal.Fusion (stream, reverseStream, unstream)
 import Data.Text.Internal.Private (span_)
-import Data.Text.Internal (Text(..), empty, firstf, mul, safe, text, append)
+import Data.Text.Internal (Text(..), empty, firstf, mul, safe, text, append, pack)
 import Data.Text.Internal.Unsafe.Char (unsafeWrite, unsafeChr8)
 import Data.Text.Show (singleton, unpack, unpackCString#, unpackCStringAscii#)
 import qualified Prelude as P
@@ -451,18 +451,6 @@ compareText (Text arrA offA lenA) (Text arrB offB lenB) =
 -- This is not a mistake: on contrary to UTF-16 (https://github.com/haskell/text/pull/208),
 -- lexicographic ordering of UTF-8 encoded strings matches lexicographic ordering
 -- of underlying bytearrays, no decoding is needed.
-
--- -----------------------------------------------------------------------------
--- * Conversion to/from 'Text'
-
--- | /O(n)/ Convert a 'String' into a 'Text'.
--- Performs replacement on invalid scalar values, so @'unpack' . 'pack'@ is not 'id':
---
--- >>> unpack (pack "\55555")
--- "\65533"
-pack :: String -> Text
-pack = unstream . S.map safe . S.streamList
-{-# INLINE [1] pack #-}
 
 -- -----------------------------------------------------------------------------
 -- * Basic functions

--- a/tests/Tests/Properties/LowLevel.hs
+++ b/tests/Tests/Properties/LowLevel.hs
@@ -131,7 +131,10 @@ testLowLevel =
         [ (`hasNoTypes` [''Char, ''[]])
         , (`doesNotUseAnyOf` ['T.pack, 'S.unstream, 'T.map, 'safe, 'S.streamList])
         , (`doesNotUseAnyOf` ['GHC.unpackCString#, 'GHC.unpackCStringUtf8#])
+#if MIN_VERSION_base(4,10,0)
+        -- skip this test for GHC 8.0
         , (`doesNotUseAnyOf` ['T.unpackCString#, 'T.unpackCStringAscii#])
+#endif
         ]
         't_literal_foo)
 #endif


### PR DESCRIPTION
Closes #464. 

What I don't really understand is why in spite of `{-# NOINLINE unpackCStringAscii# #-}` and `{-# NOINLINE unpackCString# #-}` GHC still applies worker-wrapper transformation:

```haskell
-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
emojis1857 :: Addr#
emojis1857
  = "\\240\\159\\143\\180\\243\\160\\129\\167\\243\\160\\129\\162\\243\\160\\129\\183\\243\\160\\129\\172\\243\\160\\129\\179\\243\\160\\129\\191"#

-- RHS size: {terms: 8, types: 10, coercions: 0, joins: 0/0}
emojis1856 :: Text
emojis1856
  = case $wunpackCString# emojis1857 of
    { (# ww1_ahS0, ww2_ahS1, ww3_ahS2 #) ->
    Text ww1_ahS0 ww2_ahS1 ww3_ahS2
    }

-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
emojis1859 :: Addr#
emojis1859 = "wales"#

-- RHS size: {terms: 8, types: 10, coercions: 0, joins: 0/0}
emojis1858 :: Text
emojis1858
  = case $wunpackCStringAscii# emojis1859 of
    { (# ww1_ahS6, ww2_ahS7, ww3_ahS8 #) ->
    Text ww1_ahS6 ww2_ahS7 ww3_ahS8
    }
```

This does not happen with `text-1.2.5.0`:

```haskell
-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
emojis1857 :: Addr#
emojis1857
  = "\\240\\159\\143\\180\\243\\160\\129\\167\\243\\160\\129\\162\\243\\160\\129\\183\\243\\160\\129\\172\\243\\160\\129\\179\\243\\160\\129\\191"#

-- RHS size: {terms: 2, types: 0, coercions: 0, joins: 0/0}
emojis1856 :: Text
emojis1856 = unpackCString# emojis1857

-- RHS size: {terms: 1, types: 0, coercions: 0, joins: 0/0}
emojis1859 :: Addr#
emojis1859 = "wales"#

-- RHS size: {terms: 2, types: 0, coercions: 0, joins: 0/0}
emojis1858 :: Text
emojis1858 = unpackCString# emojis1859
```

@AndreasPK any ideas?

@sjakobi does it help to reduce compile times?

CC @jgm @mpickering 