### PR TITLE
Switch Data.Text.Array to Data.Array.Byte

### DIFF
--- a/.github/workflows/emulated.yml
+++ b/.github/workflows/emulated.yml
@@ -30,8 +30,9 @@ jobs:
         githubToken: ${{ github.token }}
         install: |
           apt-get update -y
-          apt-get install -y ghc libghc-tasty-quickcheck-dev libghc-tasty-hunit-dev
+          apt-get install -y curl ghc libghc-tasty-quickcheck-dev libghc-tasty-hunit-dev
         run: |
+          curl -s https://hackage.haskell.org/package/data-array-byte-0.1/data-array-byte-0.1.tar.gz | tar xz
           ghc --version
-          ghc --make -isrc:tests -o Main cbits/*.c tests/Tests.hs +RTS -s
+          ghc --make -isrc:tests:data-array-byte-0.1 -o Main cbits/*.c tests/Tests.hs +RTS -s
           ./Main +RTS -s

--- a/src/Data/Text/Array.hs
+++ b/src/Data/Text/Array.hs
@@ -1,5 +1,12 @@
-{-# LANGUAGE BangPatterns, CPP, MagicHash, RankNTypes,
-    RecordWildCards, UnboxedTuples, UnliftedFFITypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UnliftedFFITypes #-}
+
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 -- |
 -- Module      : Data.Text.Array
@@ -24,8 +31,10 @@
 module Data.Text.Array
     (
     -- * Types
-      Array(..)
-    , MArray(..)
+      Array
+    , pattern ByteArray
+    , MArray
+    , pattern MutableByteArray
     -- * Functions
     , resizeM
     , shrinkM
@@ -60,12 +69,13 @@ import GHC.ST (ST(..), runST)
 import GHC.Word (Word8(..))
 import qualified Prelude
 import Prelude hiding (length, read, compare)
+import Data.Array.Byte (ByteArray(..), MutableByteArray(..))
 
 -- | Immutable array type.
-data Array = ByteArray ByteArray#
+type Array = ByteArray
 
 -- | Mutable array type, for use in the ST monad.
-data MArray s = MutableByteArray (MutableByteArray# s)
+type MArray = MutableByteArray
 
 -- | Create an uninitialized mutable array.
 new :: forall s. Int -> ST s (MArray s)

--- a/text.cabal
+++ b/text.cabal
@@ -195,6 +195,9 @@ library
     ghc-prim         >= 0.2 && < 0.11,
     template-haskell >= 2.5 && < 2.21
 
+  if impl(ghc < 9.4)
+    build-depends: data-array-byte >= 0.1 && < 0.2
+
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)
     ghc-options: -fno-ignore-asserts


### PR DESCRIPTION
This is a part of a grand plan to unify `ShortByteString`, `Data.Text.Array` and `Data.Primitive.ByteArray` to share the same data type. If it looks good, I'll make a release of `data-array-byte` package.