### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/scripts/Arsec.hs
+++ b/scripts/Arsec.hs
@@ -15,10 +15,11 @@ module Arsec
     , module Text.ParserCombinators.Parsec.Prim
     ) where
 
+import Prelude hiding (head, tail)
 import Control.Monad
 import Control.Applicative
 import Data.Char
-import Numeric
+import Numeric (readHex, showHex)
 import Text.ParserCombinators.Parsec.Char hiding (lower, upper)
 import Text.ParserCombinators.Parsec.Combinator hiding (optional)
 import Text.ParserCombinators.Parsec.Error
@@ -27,7 +28,11 @@ import Text.ParserCombinators.Parsec.Prim hiding ((<|>), many)
 type Comment = String
 
 unichar :: Parser Char
-unichar = chr . fst . head . readHex <$> many1 hexDigit
+unichar = do
+  digits <- many1 hexDigit
+  case readHex digits of
+    [] -> error "unichar: cannot parse hex digits"
+    (hd, _) : _ -> pure $ chr hd
 
 unichars :: Parser [Char]
 unichars = manyTill (unichar <* spaces) semi

--- a/tests/Tests/Properties/Basics.hs
+++ b/tests/Tests/Properties/Basics.hs
@@ -2,7 +2,9 @@
 
 {-# LANGUAGE ViewPatterns #-}
 
-{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-missing-signatures    #-}
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
 module Tests.Properties.Basics
     ( testBasics
     ) where

--- a/tests/Tests/Properties/LowLevel.hs
+++ b/tests/Tests/Properties/LowLevel.hs
@@ -13,6 +13,7 @@
 
 module Tests.Properties.LowLevel (testLowLevel) where
 
+import Prelude hiding (head, tail)
 import Control.Applicative ((<$>), pure)
 import Control.Exception as E (SomeException, catch, evaluate)
 import Data.Int (Int32, Int64)
@@ -101,9 +102,9 @@ t_literal_foo = T.pack "foo"
 t_write_read = write_read T.unlines T.filter T.hPutStr T.hGetContents
 tl_write_read = write_read TL.unlines TL.filter TL.hPutStr TL.hGetContents
 
-t_write_read_line m b t = write_read head T.filter T.hPutStrLn
+t_write_read_line m b t = write_read (T.concat . take 1) T.filter T.hPutStrLn
                             T.hGetLine m b [t]
-tl_write_read_line m b t = write_read head TL.filter TL.hPutStrLn
+tl_write_read_line m b t = write_read (TL.concat . take 1) TL.filter TL.hPutStrLn
                              TL.hGetLine m b [t]
 
 

--- a/tests/Tests/Properties/Transcoding.hs
+++ b/tests/Tests/Properties/Transcoding.hs
@@ -6,6 +6,7 @@ module Tests.Properties.Transcoding
     ( testTranscoding
     ) where
 
+import Prelude hiding (head, tail)
 import Data.Bits ((.&.), shiftR)
 import Data.Char (chr, ord)
 import Test.QuickCheck hiding ((.&.))
@@ -82,7 +83,7 @@ feedChunksOf n f bs
 t_utf8_undecoded t =
   let b = E.encodeUtf8 t
       ls = concatMap (leftover . E.encodeUtf8 . T.singleton) . T.unpack $ t
-      leftover = (++ [B.empty]) . init . tail . B.inits
+      leftover = (++ [B.empty]) . init . drop 1 . B.inits
   in (map snd . feedChunksOf 1 E.streamDecodeUtf8) b === ls
 
 data InvalidUtf8 = InvalidUtf8


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates `head` and `tail` or quashes the warning by other means.