### PR TITLE
Avoid Data.List.{head,tail} again

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -225,7 +225,7 @@ import Control.Monad (foldM)
 import Control.Monad.ST (ST, runST)
 import Control.Monad.ST.Unsafe (unsafeIOToST)
 import qualified Data.Text.Array as A
-import qualified Data.List as L
+import qualified Data.List as L hiding (head, tail)
 import Data.Binary (Binary(get, put))
 import Data.Monoid (Monoid(..))
 import Data.Semigroup (Semigroup(..))

--- a/src/Data/Text/Internal/Fusion/Common.hs
+++ b/src/Data/Text/Internal/Fusion/Common.hs
@@ -123,7 +123,7 @@ module Data.Text.Internal.Fusion.Common
 import Prelude (Bool(..), Char, Eq, (==), Int, Integral, Maybe(..),
                 Ord(..), Ordering(..), String, (.), ($), (+), (-), (*), (++),
                 (&&), fromIntegral, otherwise)
-import qualified Data.List as L
+import qualified Data.List as L hiding (head, tail)
 import qualified Prelude as P
 import Data.Bits (shiftL, shiftR, (.&.))
 import Data.Char (isLetter, isSpace)

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -210,7 +210,7 @@ import Control.Arrow (first)
 import Control.DeepSeq (NFData(..))
 import Data.Bits (finiteBitSize)
 import Data.Int (Int64)
-import qualified Data.List as L
+import qualified Data.List as L hiding (head, tail)
 import Data.Char (isSpace)
 import Data.Data (Data(gfoldl, toConstr, gunfold, dataTypeOf), constrIndex,
                   Constr, mkConstr, DataType, mkDataType, Fixity(Prefix))
@@ -1405,7 +1405,7 @@ groupBy eq (Chunk t ts) = cons x ys : groupBy eq zs
 inits :: Text -> [Text]
 inits = (Empty :) . inits'
   where inits' Empty        = []
-        inits' (Chunk t ts) = L.map (\t' -> Chunk t' Empty) (L.tail (T.inits t))
+        inits' (Chunk t ts) = L.map (\t' -> Chunk t' Empty) (L.drop 1 (T.inits t))
                            ++ L.map (Chunk t) (inits' ts)
 
 -- | /O(n)/ Return all final segments of the given 'Text', longest


### PR DESCRIPTION
Continuing #476. Apparently my grep fu was weak last time.