### PR TITLE
ci: Fix run-haddock flag

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -63,19 +63,16 @@ jobs:
             compilerVersion: 8.4.4
             setup-method: ghcup
             allow-failure: false
-            run-haddock: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
             setup-method: ghcup
             allow-failure: false
-            run-haddock: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
             setup-method: ghcup
             allow-failure: false
-            run-haddock: false
       fail-fast: false
     steps:
       - name: apt
@@ -231,9 +228,8 @@ jobs:
           cd ${PKGDIR_text} || false
           ${CABAL} -vnormal check
       - name: haddock
-        if: ${{ matrix.run_haddock != false }}
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,4 @@
 ghcup-jobs: >=8.0
 docspec: True
 docspec-options: --timeout 2
+haddock: >=8.6


### PR DESCRIPTION
I typoed the variable name so haddock was never run, and I didn't find a way to have a default value when the variable is unset, so I had to set it for each job.