### PR TITLE
Declare pure FFI functions as not living in IO

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1371,13 +1371,13 @@ take n t@(Text arr off len)
 -- @since 2.0
 measureOff :: Int -> Text -> Int
 measureOff !n (Text (A.ByteArray arr) off len) = if len == 0 then 0 else
-  cSsizeToInt $ unsafeDupablePerformIO $
+  cSsizeToInt $
     c_measure_off arr (intToCSize off) (intToCSize len) (intToCSize n)
 
 -- | The input buffer (arr :: ByteArray#, off :: CSize, len :: CSize)
 -- must specify a valid UTF-8 sequence, this condition is not checked.
 foreign import ccall unsafe "_hs_text_measure_off" c_measure_off
-    :: ByteArray# -> CSize -> CSize -> CSize -> IO CSsize
+    :: ByteArray# -> CSize -> CSize -> CSize -> CSsize
 
 -- | /O(n)/ 'takeEnd' @n@ @t@ returns the suffix remaining after
 -- taking @n@ characters from the end of @t@.
@@ -2018,12 +2018,12 @@ lines (Text arr@(A.ByteArray arr#) off len) = go off
       | delta < 0 = [Text arr n (len + off - n)]
       | otherwise = Text arr n delta : go (n + delta + 1)
       where
-        delta = cSsizeToInt $ unsafeDupablePerformIO $
+        delta = cSsizeToInt $
           memchr arr# (intToCSize n) (intToCSize (len + off - n)) 0x0A
 {-# INLINE lines #-}
 
 foreign import ccall unsafe "_hs_text_memchr" memchr
-    :: ByteArray# -> CSize -> CSize -> Word8 -> IO CSsize
+    :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize
 
 -- | /O(n)/ Joins lines, after appending a terminating newline to
 -- each.

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -243,7 +243,6 @@ import Data.Text.Show (singleton, unpack, unpackCString#, unpackCStringAscii#)
 import qualified Prelude as P
 import Data.Text.Unsafe (Iter(..), iter, iter_, lengthWord8, reverseIter,
                          reverseIter_, unsafeHead, unsafeTail, iterArray, reverseIterArray)
-import Data.Text.Foreign (asForeignPtr)
 import Data.Text.Internal.Search (indices)
 #if defined(__HADDOCK__)
 import Data.ByteString (ByteString)
@@ -259,7 +258,11 @@ import qualified Language.Haskell.TH.Lib as TH
 import qualified Language.Haskell.TH.Syntax as TH
 import Text.Printf (PrintfArg, formatArg, formatString)
 import System.Posix.Types (CSsize(..))
+
+#if MIN_VERSION_template_haskell(2,16,0)
+import Data.Text.Foreign (asForeignPtr)
 import System.IO.Unsafe (unsafePerformIO)
+#endif
 
 -- $setup
 -- >>> :set -package transformers
@@ -425,6 +428,7 @@ instance TH.Lift Text where
   liftTyped = TH.unsafeTExpCoerce . TH.lift
 #endif
 
+#if MIN_VERSION_template_haskell(2,16,0)
 unpackCStringLen# :: Exts.Addr# -> Int -> Text
 unpackCStringLen# addr# l = Text ba 0 l
   where
@@ -433,6 +437,7 @@ unpackCStringLen# addr# l = Text ba 0 l
       A.copyFromPointer marr 0 (Exts.Ptr addr#) l
       A.unsafeFreeze marr
 {-# NOINLINE unpackCStringLen# #-} -- set as NOINLINE to avoid generated code bloat
+#endif
 
 -- | @since 1.2.2.0
 instance PrintfArg Text where

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -242,7 +242,7 @@ import Data.Text.Internal.Unsafe.Char (unsafeWrite, unsafeChr8)
 import Data.Text.Show (singleton, unpack, unpackCString#, unpackCStringAscii#)
 import qualified Prelude as P
 import Data.Text.Unsafe (Iter(..), iter, iter_, lengthWord8, reverseIter,
-                         reverseIter_, unsafeHead, unsafeTail, unsafeDupablePerformIO, iterArray, reverseIterArray)
+                         reverseIter_, unsafeHead, unsafeTail, iterArray, reverseIterArray)
 import Data.Text.Foreign (asForeignPtr)
 import Data.Text.Internal.Search (indices)
 #if defined(__HADDOCK__)
@@ -413,7 +413,7 @@ instance Data Text where
 instance TH.Lift Text where
 #if MIN_VERSION_template_haskell(2,16,0)
   lift txt = do
-    let (ptr, len) = unsafePerformIO $ asForeignPtr txt 
+    let (ptr, len) = unsafePerformIO $ asForeignPtr txt
     let lenInt = P.fromIntegral len
     TH.appE (TH.appE (TH.varE 'unpackCStringLen#) (TH.litE . TH.bytesPrimL $ TH.mkBytes ptr 0 lenInt)) (TH.lift lenInt)
 #else

--- a/src/Data/Text/Array.hs
+++ b/src/Data/Text/Array.hs
@@ -53,7 +53,6 @@ module Data.Text.Array
 import GHC.Stack (HasCallStack)
 #endif
 #if !MIN_VERSION_base(4,11,0)
-import Data.Text.Internal.Unsafe (inlinePerformIO)
 import Foreign.C.Types (CInt(..))
 #endif
 import GHC.Exts hiding (toList)
@@ -322,9 +321,9 @@ compareInternal (ByteArray src1#) (I# off1#) (ByteArray src2#) (I# off2#) (I# co
 #if MIN_VERSION_base(4,11,0)
     i = I# (compareByteArrays# src1# off1# src2# off2# count#)
 #else
-    i = fromIntegral (inlinePerformIO (memcmp src1# off1# src2# off2# count#))
+    i = fromIntegral (memcmp src1# off1# src2# off2# count#)
 
 foreign import ccall unsafe "_hs_text_memcmp2" memcmp
-    :: ByteArray# -> Int# -> ByteArray# -> Int# -> Int# -> IO CInt
+    :: ByteArray# -> Int# -> ByteArray# -> Int# -> Int# -> CInt
 #endif
 {-# INLINE compareInternal #-}

--- a/src/Data/Text/Internal/Lazy/Search.hs
+++ b/src/Data/Text/Internal/Lazy/Search.hs
@@ -66,7 +66,7 @@ indices needle
          c = index xxs (i + nlast)
          delta | nextInPattern = nlen + 1
                | c == z        = skip + 1
-               | l >= i + nlen = case unsafeDupablePerformIO $
+               | l >= i + nlen = case
                   memchr xarr# (intToCSize (xoff + i + nlen)) (intToCSize (l - i - nlen)) z of
                     -1 -> max 1 (l - i - nlen)
                     s  -> cSsizeToInt s + 1
@@ -142,4 +142,4 @@ cSsizeToInt :: CSsize -> Int
 cSsizeToInt = fromIntegral
 
 foreign import ccall unsafe "_hs_text_memchr" memchr
-    :: ByteArray# -> CSize -> CSize -> Word8 -> IO CSsize
+    :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize

--- a/src/Data/Text/Internal/Lazy/Search.hs
+++ b/src/Data/Text/Internal/Lazy/Search.hs
@@ -32,7 +32,6 @@ import qualified Data.Text.Internal as T
 import qualified Data.Text as T (concat, isPrefixOf)
 import Data.Text.Internal.Fusion.Types (PairS(..))
 import Data.Text.Internal.Lazy (Text(..), foldrChunks)
-import Data.Text.Unsafe (unsafeDupablePerformIO)
 import Data.Bits ((.|.), (.&.))
 import Foreign.C.Types
 import GHC.Exts (ByteArray#)

--- a/src/Data/Text/Internal/Search.hs
+++ b/src/Data/Text/Internal/Search.hs
@@ -37,7 +37,6 @@ import qualified Data.Text.Array as A
 import Data.Word (Word64, Word8)
 import Data.Text.Internal (Text(..))
 import Data.Bits ((.|.), (.&.), unsafeShiftL)
-import Data.Text.Unsafe (unsafeDupablePerformIO)
 import Foreign.C.Types
 import GHC.Exts (ByteArray#)
 import System.Posix.Types (CSsize(..))

--- a/src/Data/Text/Internal/Search.hs
+++ b/src/Data/Text/Internal/Search.hs
@@ -88,7 +88,7 @@ indices' (Text narr noff nlen) (Text harr@(A.ByteArray harr#) hoff hlen) = loop 
       | mask .&. swizzle (A.unsafeIndex harr i) == 0
       = loop (i + nlen + 1)
       | otherwise
-      = case unsafeDupablePerformIO $ memchr harr# (intToCSize i) (intToCSize (hlen + hoff - i)) z of
+      = case memchr harr# (intToCSize i) (intToCSize (hlen + hoff - i)) z of
         -1 -> []
         x  -> loop (i + cSsizeToInt x + 1)
 {-# INLINE indices' #-}
@@ -112,4 +112,4 @@ cSsizeToInt :: CSsize -> Int
 cSsizeToInt = fromIntegral
 
 foreign import ccall unsafe "_hs_text_memchr" memchr
-    :: ByteArray# -> CSize -> CSize -> Word8 -> IO CSsize
+    :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize

--- a/src/Data/Text/Show.hs
+++ b/src/Data/Text/Show.hs
@@ -33,7 +33,6 @@ import GHC.Word (Word8(..))
 import qualified Data.Text.Array as A
 import qualified Data.Text.Internal.Fusion.Common as S
 #if !MIN_VERSION_ghc_prim(0,7,0)
-import Data.Text.Internal.Unsafe (inlinePerformIO)
 import Foreign.C.String (CString)
 import Foreign.C.Types (CSize(..))
 #endif
@@ -112,9 +111,9 @@ addrLen :: Addr# -> Int
 #if MIN_VERSION_ghc_prim(0,7,0)
 addrLen addr# = I# (GHC.cstringLength# addr#)
 #else
-addrLen addr# = fromIntegral (inlinePerformIO (c_strlen (Ptr addr#)))
+addrLen addr# = fromIntegral (c_strlen (Ptr addr#))
 
-foreign import capi unsafe "string.h strlen" c_strlen :: CString -> IO CSize
+foreign import capi unsafe "string.h strlen" c_strlen :: CString -> CSize
 #endif
 
 {-# RULES "TEXT literal" forall a.


### PR DESCRIPTION
# Synopsis

In some places `text` uses `unsafeDupablePerformIO` which forces allocation of thunk for its result. Most of those cases are for foreign functions which are morally equivalent to C’s `sin` (sine calculation) function in the sense that they’re actually pure.

This PR removes the thunk mentioned by not introducing `IO` in those cases.

## Thunk discussion

Due to some recent-ish fix `unsafeDupablePerformIO` (https://gitlab.haskell.org/ghc/ghc/-/issues/19181) the function now uses `GHC.Magic.lazy` which forces thunk allocation and no optimization will ever make it cease to do so.

For instance, with current implementation of `length` for text the resulting length is always wrapped into a thunk even if demanded strictly.

For example, next is the core of the worker for the function `foo` that takes text’s length.

```haskell
#!/usr/bin/env cabal
{- cabal:
build-depends:
  , base
  , text > 2.0
-}

{-# LANGUAGE BangPatterns #-}

{-# OPTIONS_GHC -O2 #-}
{-# OPTIONS_GHC -ddump-simpl -dsuppress-uniques -dsuppress-idinfo -dsuppress-module-prefixes -dsuppress-type-applications -dsuppress-coercions -dppr-cols200 -dsuppress-type-signatures -ddump-to-file #-}

module Main (foo, main) where

import Data.Text (Text)
import qualified Data.Text as T
import qualified Data.Text.IO as T

foo :: Text -> Int
foo !x = len + len
  where
    !len = T.length x

main :: IO ()
main =
  print =<< foo <$> T.getContents

```

By running `cabal run ./Main.hs <Main.hs` with GHC 9.4.3:

```haskell
-- RHS size: {terms: 31, types: 20, coercions: 3, joins: 0/0}
$wfoo
  = \ ww ww1 ww2 ->
      case ww2 of wild1 {
        __DEFAULT ->
          runRW#
            (\ s ->
               case {__ffi_static_ccall_unsafe text-2.0.1:_hs_text_measure_off :: ByteArray#
                                                              -> Word64#
                                                              -> Word64#
                                                              -> Word64#
                                                              -> State# RealWorld
                                                              -> (# State# RealWorld, Int64# #)}
                      ww (int64ToWord64# (intToInt64# ww1)) (int64ToWord64# (intToInt64# wild1)) 9223372036854775807##64 s
               of
               { (# ds, ds1 #) ->
               case (lazy ((I64# ds1) `cast` <Co:2> :: Int64 ~R# CSsize)) `cast` <Co:1> :: CSsize ~R# Int64 of { I64# x1 ->
               *# -2# (int64ToInt# x1)
               }
               });
        0# -> 0#
      }
```

Result of `_hs_text_measure_off` is lazily allocate before bein consumed.

## Ways to remove thunk

In order to remove the extra thunk the `Data.Bytestring.Internal.accursedUnutterablePerformIO` function could be used, or its cousing in the `text` package `Data.Text.Internal.Unsafe.inlinePerformIO`. Their definitions are equivalent so they should be equally unsafe, accursed and unutterable.

The accursedness and unutterability of those functions mosty comes from their interaction with GHC’s optimizer. When arbitrary IO action is supplied to them some invariants may be violated. But when a FFI wrapper like `_hs_text_measure_off` is supplied then it’s not so bad since GHC never sees inside the wrapper.

However with FFI wrappers it’s not mandatory to make them operate in IO. C’s wrapper for trigonometric sine caculation, `sin`, is declared pure because it’s pure and doesn’t have side effects. IO is important if the wrapped function is going to become part of bigger IO action where ordering of effects doesn’t matter. I argue that functions like `_hs_text_measure_off` in the text package are actually like C’s `sin` and may be declared pure from the start, which this PR does to some extent.

By going this route there’s not need for any variety of unsafe perform IO since there’s no IO.

As a side effect of this PR the `Data.Text.Internal.Unsafe.inlinePerformIO` can probably be deprecated at some point in the future when other two uses of it in the `Data.Text.Internal.IO` module are dealt with.
