### PR TITLE
Allow building with template-haskell-2.20.*

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -191,7 +191,7 @@ library
     bytestring       >= 0.10.4 && < 0.12,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.11,
-    template-haskell >= 2.5 && < 2.20
+    template-haskell >= 2.5 && < 2.21
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)


### PR DESCRIPTION
This is the version that GHC 9.6 is going to ship with.

See also: https://gitlab.haskell.org/ghc/ghc/-/issues/22767