### PR TITLE
Bump template-haskell to accommodate 2.20

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -187,7 +187,7 @@ library
     bytestring       >= 0.10.4 && < 0.12,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.11,
-    template-haskell >= 2.5 && < 2.20
+    template-haskell >= 2.5 && < 2.21
 
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
   if flag(developer)


### PR DESCRIPTION
This will ship with GHC 9.6.