### PR TITLE
pack: shrink the backing mutable byte array after 'Chars' have been added

### DIFF
--- a/src/Data/Text/Internal.hs
+++ b/src/Data/Text/Internal.hs
@@ -251,6 +251,10 @@ pack xs = runST $ do
         d <- unsafeWrite marr off (safe c)
         go (off + d) cs
   len <- go 0 xs
+  -- On average, the number of bytes taken by a typical 'Char' is less than 4 in UTF-8
+  -- (only 1 to 2 bytes for latin-script languages for instance), so we shrink the array
+  -- now. Could mean substantial memory savings for a long 'String'.
+  A.shrinkM marr len
   arr <- A.unsafeFreeze marr
   return (Text arr 0 len)
 {-# NOINLINE [0] pack #-}


### PR DESCRIPTION
The `pack` function converts a `String` to `Text`. It allocates 4 bytes per `Char` into a mutable byte array (as a UTF-8 character will take 4 bytes in the worse case). After all the `Char`s have been written to the byte array, we should shrink the mutable byte array to the actual size required.

This shrinking operation does not seem to be present. This PR adds it. This should lead to substantial memory savings for long `String`s.

Sorry if I've not understood something. Let me know if the `shrinkM` is not required.