### PR TITLE
add C-based `isAscii :: Text -> Bool`

### DIFF
--- a/cbits/is_ascii.c
+++ b/cbits/is_ascii.c
@@ -48,5 +48,5 @@ const size_t _hs_text_is_ascii(const uint8_t *src0, const uint8_t *srcend){
 
 // TODO wrapper for using with ByteArray#
 const size_t _hs_text_is_ascii_2(const uint8_t *arr, size_t off, size_t len){
-    return _hs_text_is_ascii(arr + off, arr + len);
+    return _hs_text_is_ascii(arr + off, arr + off + len);
 }

--- a/cbits/is_ascii.c
+++ b/cbits/is_ascii.c
@@ -45,3 +45,8 @@ const size_t _hs_text_is_ascii(const uint8_t *src0, const uint8_t *srcend){
 
   return src - src0;
 }
+
+// TODO wrapper for using with ByteArray#
+const size_t _hs_text_is_ascii_2(const uint8_t *arr, size_t off, size_t len){
+    return _hs_text_is_ascii(arr + off, arr + len);
+}

--- a/cbits/is_ascii.c
+++ b/cbits/is_ascii.c
@@ -47,8 +47,8 @@ const size_t _hs_text_is_ascii(const uint8_t *src0, const uint8_t *srcend){
 }
 
 /*
-  _hs_text_is_ascii_wrapper is a helper for calling _hs_text_is_ascii on Texts.
+  _hs_text_is_ascii_offset is a helper for calling _hs_text_is_ascii on Texts.
 */
-const size_t _hs_text_is_ascii_2(const uint8_t *arr, size_t off, size_t len){
+const size_t _hs_text_is_ascii_offset(const uint8_t *arr, size_t off, size_t len){
     return _hs_text_is_ascii(arr + off, arr + off + len);
 }

--- a/cbits/is_ascii.c
+++ b/cbits/is_ascii.c
@@ -46,7 +46,9 @@ const size_t _hs_text_is_ascii(const uint8_t *src0, const uint8_t *srcend){
   return src - src0;
 }
 
-// TODO wrapper for using with ByteArray#
+/*
+  _hs_text_is_ascii_wrapper is a helper for calling _hs_text_is_ascii on Texts.
+*/
 const size_t _hs_text_is_ascii_2(const uint8_t *arr, size_t off, size_t len){
     return _hs_text_is_ascii(arr + off, arr + off + len);
 }

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1193,7 +1193,7 @@ minimum t = S.minimum (stream t)
 --
 -- prop> isAscii t == all (< '\x80') t
 --
--- @since 2.0.2 (?) TODO
+-- @since 2.0.2
 isAscii :: Text -> Bool
 isAscii (Text (A.ByteArray arr) off len) =
     cSizeToInt (c_is_ascii_offset arr (intToCSize off) (intToCSize len)) == len

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -266,7 +266,6 @@ import System.IO.Unsafe (unsafePerformIO)
 #endif
 
 import Foreign.Ptr ( plusPtr )
-import System.IO.Unsafe (unsafeDupablePerformIO)
 
 -- $setup
 -- >>> :set -package transformers
@@ -1182,18 +1181,16 @@ minimum t = S.minimum (stream t)
 
 -- TODO
 isAscii :: Text -> Bool
-isAscii (Text (A.ByteArray arr) off len) =
-    let arrPtr = Exts.Ptr (Exts.byteArrayContents# arr)
-        check = c_is_ascii (arrPtr `plusPtr` off) (arrPtr `plusPtr` len)
-    in  cSizeToInt (unsafeDupablePerformIO check) == len
+isAscii (Text (A.ByteArray arr) (Exts.I# off#) (Exts.I# len#)) =
+    cSizeToInt (c_is_ascii_2 arr off# len#) == (Exts.I# len#)
 {-# INLINE isAscii #-}
 
 cSizeToInt :: CSize -> Int
 cSizeToInt = P.fromIntegral
 {-# INLINE cSizeToInt #-}
 
-foreign import ccall unsafe "_hs_text_is_ascii" c_is_ascii
-    :: Exts.Ptr Word8 -> Exts.Ptr Word8 -> IO CSize
+foreign import ccall unsafe "_hs_text_is_ascii_2" c_is_ascii_2
+    :: ByteArray# -> Exts.Int# -> Exts.Int# -> CSize
 
 -- -----------------------------------------------------------------------------
 -- * Building 'Text's

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1177,7 +1177,23 @@ minimum :: HasCallStack => Text -> Char
 minimum t = S.minimum (stream t)
 {-# INLINE minimum #-}
 
--- TODO
+-- | \O(n)\ Test whether 'Text' contains only ASCII code-points (i.e. only
+--   U+0000 through U+007F).
+--
+-- This is a more efficient version of @'all' 'Data.Char.isAscii'@.
+--
+-- >>> isAscii ""
+-- True
+--
+-- >>> isAscii "abc\NUL"
+-- True
+--
+-- >>> isAscii "abcd€"
+-- False
+--
+-- prop> isAscii t == all (< '\x80') t
+--
+-- @since 2.0.2 (?) TODO
 isAscii :: Text -> Bool
 isAscii (Text (A.ByteArray arr) off len) =
     cSizeToInt (c_is_ascii_2 arr (intToCSize off) (intToCSize len)) == len

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -265,8 +265,6 @@ import Data.Text.Foreign (asForeignPtr)
 import System.IO.Unsafe (unsafePerformIO)
 #endif
 
-import Foreign.Ptr ( plusPtr )
-
 -- $setup
 -- >>> :set -package transformers
 -- >>> import Control.Monad.Trans.State
@@ -1181,8 +1179,8 @@ minimum t = S.minimum (stream t)
 
 -- TODO
 isAscii :: Text -> Bool
-isAscii (Text (A.ByteArray arr) (Exts.I# off#) (Exts.I# len#)) =
-    cSizeToInt (c_is_ascii_2 arr off# len#) == (Exts.I# len#)
+isAscii (Text (A.ByteArray arr) off len) =
+    cSizeToInt (c_is_ascii_2 arr (intToCSize off) (intToCSize len)) == len
 {-# INLINE isAscii #-}
 
 cSizeToInt :: CSize -> Int
@@ -1190,7 +1188,7 @@ cSizeToInt = P.fromIntegral
 {-# INLINE cSizeToInt #-}
 
 foreign import ccall unsafe "_hs_text_is_ascii_2" c_is_ascii_2
-    :: ByteArray# -> Exts.Int# -> Exts.Int# -> CSize
+    :: ByteArray# -> CSize -> CSize -> CSize
 
 -- -----------------------------------------------------------------------------
 -- * Building 'Text's

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -1196,14 +1196,14 @@ minimum t = S.minimum (stream t)
 -- @since 2.0.2 (?) TODO
 isAscii :: Text -> Bool
 isAscii (Text (A.ByteArray arr) off len) =
-    cSizeToInt (c_is_ascii_2 arr (intToCSize off) (intToCSize len)) == len
+    cSizeToInt (c_is_ascii_offset arr (intToCSize off) (intToCSize len)) == len
 {-# INLINE isAscii #-}
 
 cSizeToInt :: CSize -> Int
 cSizeToInt = P.fromIntegral
 {-# INLINE cSizeToInt #-}
 
-foreign import ccall unsafe "_hs_text_is_ascii_2" c_is_ascii_2
+foreign import ccall unsafe "_hs_text_is_ascii_offset" c_is_ascii_offset
     :: ByteArray# -> CSize -> CSize -> CSize
 
 -- -----------------------------------------------------------------------------

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -889,8 +889,7 @@ minimum t = S.minimum (stream t)
 --
 -- @since 2.0.2
 isAscii :: Text -> Bool
-isAscii Empty = True
-isAscii (Chunk c cs) = T.isAscii c && isAscii cs
+isAscii = foldrChunks (\chnk acc -> T.isAscii chnk && acc) True
 
 -- | /O(n)/ 'scanl' is similar to 'foldl', but returns a list of
 -- successive reduced values from the left.

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -108,6 +108,7 @@ module Data.Text.Lazy
     , all
     , maximum
     , minimum
+    , isAscii
 
     -- * Construction
 
@@ -869,6 +870,27 @@ maximum t = S.maximum (stream t)
 minimum :: HasCallStack => Text -> Char
 minimum t = S.minimum (stream t)
 {-# INLINE minimum #-}
+
+-- | \O(n)\ Test whether 'Text' contains only ASCII code-points (i.e. only
+--   U+0000 through U+007F).
+--
+-- This is a more efficient version of @'all' 'Data.Char.isAscii'@.
+--
+-- >>> isAscii ""
+-- True
+--
+-- >>> isAscii "abc\NUL"
+-- True
+--
+-- >>> isAscii "abcd€"
+-- False
+--
+-- prop> isAscii t == all (< '\x80') t
+--
+-- @since 2.0.2 (?) TODO
+isAscii :: Text -> Bool
+isAscii Empty = True
+isAscii (Chunk c cs) = T.isAscii c && isAscii cs
 
 -- | /O(n)/ 'scanl' is similar to 'foldl', but returns a list of
 -- successive reduced values from the left.

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -887,7 +887,7 @@ minimum t = S.minimum (stream t)
 --
 -- prop> isAscii t == all (< '\x80') t
 --
--- @since 2.0.2 (?) TODO
+-- @since 2.0.2
 isAscii :: Text -> Bool
 isAscii Empty = True
 isAscii (Chunk c cs) = T.isAscii c && isAscii cs

--- a/tests/Tests/Properties/Folds.hs
+++ b/tests/Tests/Properties/Folds.hs
@@ -20,7 +20,6 @@ import qualified Data.Text.Internal.Fusion as S
 import qualified Data.Text.Internal.Fusion.Common as S
 import qualified Data.Text.Lazy as TL
 import qualified Data.Char as Char
-import qualified Data.Text.Internal as T
 
 -- Folds
 

--- a/tests/Tests/Properties/Folds.hs
+++ b/tests/Tests/Properties/Folds.hs
@@ -19,6 +19,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Internal.Fusion as S
 import qualified Data.Text.Internal.Fusion.Common as S
 import qualified Data.Text.Lazy as TL
+import qualified Data.Char as Char
 
 -- Folds
 
@@ -109,6 +110,9 @@ sf_minimum (applyFun -> p)
                   = (L.minimum . L.filter p) `eqP` (S.minimum . S.filter p)
 t_minimum         = L.minimum     `eqP` T.minimum
 tl_minimum        = L.minimum     `eqP` TL.minimum
+--sf_isAscii = L.all Char.isAscii `eq` TODO
+t_isAscii = L.all Char.isAscii `eqP` T.isAscii
+--tl_isAscii = L.all Char.isAscii `eq` 
 
 -- Scans
 
@@ -234,7 +238,8 @@ testFolds =
         testProperty "tl_maximum" tl_maximum,
         testProperty "sf_minimum" sf_minimum,
         testProperty "t_minimum" t_minimum,
-        testProperty "tl_minimum" tl_minimum
+        testProperty "tl_minimum" tl_minimum,
+        testProperty "t_isAscii " t_isAscii
       ]
     ],
 

--- a/tests/Tests/Properties/Folds.hs
+++ b/tests/Tests/Properties/Folds.hs
@@ -110,9 +110,8 @@ sf_minimum (applyFun -> p)
                   = (L.minimum . L.filter p) `eqP` (S.minimum . S.filter p)
 t_minimum         = L.minimum     `eqP` T.minimum
 tl_minimum        = L.minimum     `eqP` TL.minimum
---sf_isAscii = L.all Char.isAscii `eq` TODO
-t_isAscii = L.all Char.isAscii `eqP` T.isAscii
---tl_isAscii = L.all Char.isAscii `eq` 
+t_isAscii         = L.all Char.isAscii `eqP` T.isAscii
+tl_isAscii        = L.all Char.isAscii `eqP` TL.isAscii
 
 -- Scans
 
@@ -239,7 +238,8 @@ testFolds =
         testProperty "sf_minimum" sf_minimum,
         testProperty "t_minimum" t_minimum,
         testProperty "tl_minimum" tl_minimum,
-        testProperty "t_isAscii " t_isAscii
+        testProperty "t_isAscii " t_isAscii,
+        testProperty "tl_isAscii " tl_isAscii
       ]
     ],
 

--- a/tests/Tests/Properties/Folds.hs
+++ b/tests/Tests/Properties/Folds.hs
@@ -11,7 +11,7 @@ import Control.Arrow (second)
 import Control.Exception (ErrorCall, evaluate, try)
 import Data.Word (Word8, Word16)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase, assertFailure)
+import Test.Tasty.HUnit (testCase, assertFailure, assertBool)
 import Test.Tasty.QuickCheck (testProperty, Small(..), (===), applyFun, applyFun2)
 import Tests.QuickCheckUtils
 import qualified Data.List as L
@@ -20,6 +20,7 @@ import qualified Data.Text.Internal.Fusion as S
 import qualified Data.Text.Internal.Fusion.Common as S
 import qualified Data.Text.Lazy as TL
 import qualified Data.Char as Char
+import qualified Data.Text.Internal as T
 
 -- Folds
 
@@ -193,6 +194,13 @@ tl_unfoldrN n m   = (L.take i . L.unfoldr (unf j)) `eq`
     where i = fromIntegral (n :: Word16)
           j = fromIntegral (m :: Word16)
 
+isAscii_border :: IO ()
+isAscii_border = do
+    -- ASCII prefix ends at position 3 (from 0)
+    let text  = T.pack "123一二三"
+        text' = case text of T.Text arr off _len -> T.Text arr (off+1) 3
+    assertBool "UTF-8 string with ASCII prefix ending at last position incorrectly detected as ASCII" $ not $ T.isAscii text'
+
 testFolds :: TestTree
 testFolds =
   testGroup "folds-unfolds" [
@@ -239,7 +247,8 @@ testFolds =
         testProperty "t_minimum" t_minimum,
         testProperty "tl_minimum" tl_minimum,
         testProperty "t_isAscii " t_isAscii,
-        testProperty "tl_isAscii " tl_isAscii
+        testProperty "tl_isAscii " tl_isAscii,
+        testCase "isAscii_border" isAscii_border
       ]
     ],
 

--- a/tests/Tests/Properties/Folds.hs
+++ b/tests/Tests/Properties/Folds.hs
@@ -196,10 +196,8 @@ tl_unfoldrN n m   = (L.take i . L.unfoldr (unf j)) `eq`
 
 isAscii_border :: IO ()
 isAscii_border = do
-    -- ASCII prefix ends at position 3 (from 0)
-    let text  = T.pack "123一二三"
-        text' = case text of T.Text arr off _len -> T.Text arr (off+1) 3
-    assertBool "UTF-8 string with ASCII prefix ending at last position incorrectly detected as ASCII" $ not $ T.isAscii text'
+    let text  = T.drop 2 $ T.pack "XX1234五"
+    assertBool "UTF-8 string with ASCII prefix ending at last position incorrectly detected as ASCII" $ not $ T.isAscii text
 
 testFolds :: TestTree
 testFolds =


### PR DESCRIPTION
Now that `Text`s are represented internally as a UTF-8 bytestring, we can provide a fast `isAscii :: Text -> Bool` that inspects the bytestring directly, rather than `Char` by `Char`. Such a function can come in handy in serialization libraries, and can't easily be written by an end user. Plus, the C snippet already exists, so there's not much to do.