### PR TITLE
add safe decodeASCII'

### DIFF
--- a/src/Data/Text/Encoding.hs
+++ b/src/Data/Text/Encoding.hs
@@ -31,6 +31,7 @@ module Data.Text.Encoding
     , decodeASCIIPrefix
     , decodeUtf8Lenient
     , decodeUtf8'
+    , decodeASCII'
 
     -- *** Controllable error handling
     , decodeUtf8With
@@ -176,6 +177,21 @@ asciiPrefixLength :: ByteString -> Int
 asciiPrefixLength bs = unsafeDupablePerformIO $ withBS bs $ \ fp len ->
   unsafeWithForeignPtr fp $ \src -> do
     fromIntegral <$> c_is_ascii src (src `plusPtr` len)
+
+-- | Decode a 'ByteString' containing 7-bit ASCII encoded text.
+--
+-- This is a total function which returns either the 'ByteString' converted to a
+-- 'Text' containing ASCII text, or 'Nothing'.
+--
+-- Use 'decodeASCIIPrefix' to retain the longest ASCII prefix for an invalid
+-- input instead of discarding it.
+--
+-- @since 2.0.2
+decodeASCII' :: ByteString -> Maybe Text
+decodeASCII' bs =
+  let (prefix, suffix) = decodeASCIIPrefix bs in
+  if B.null suffix then Just prefix else Nothing
+{-# INLINE decodeASCII' #-}
 
 -- | Decode a 'ByteString' containing 7-bit ASCII encoded text.
 --


### PR DESCRIPTION
Useful function for serialization libs. Currently you have to do something like [this](https://github.com/raehik/binrep/blob/06a609336c25aadd02948aedb2c6f05319050bdb/src/Binrep/Type/Text/Encoding/Ascii.hs#L26-L38), which is nasty and weird for something that isn't really inherently so.

I find the decoding setup to be a little messy and this makes no attempt to improve on that. I wouldn't mind assisting on that work too.