### PR TITLE
Set -fproc-alignment=64 for benchmarks

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -281,6 +281,8 @@ benchmark text-benchmarks
     ghc-options:  "-with-rtsopts=-A32m --nonmoving-gc"
   else
     ghc-options:  "-with-rtsopts=-A32m"
+  if impl(ghc >= 8.6)
+    ghc-options:  -fproc-alignment=64
 
   build-depends:  base,
                   bytestring >= 0.10.4,


### PR DESCRIPTION
See https://downloads.haskell.org/ghc/latest/docs/users_guide/debugging.html#ghc-flag--fproc-alignment

Otherwise comparing benchmarks between different versions of GHC could be meaningless because of different cache-line alignment.