### PR TITLE
Bump `template-haskell` bound to <2.22

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -196,7 +196,7 @@ library
     bytestring       >= 0.10.4 && < 0.12,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.11,
-    template-haskell >= 2.5 && < 2.21
+    template-haskell >= 2.5 && < 2.22
 
   if impl(ghc < 9.4)
     build-depends: data-array-byte >= 0.1 && < 0.2


### PR DESCRIPTION
For GHC 9.8. See https://gitlab.haskell.org/ghc/ghc/-/issues/23563#note_507870.