### PR TITLE
Support bytestring-0.12

### DIFF
--- a/src/Data/Text/IO/Utf8.hs
+++ b/src/Data/Text/IO/Utf8.hs
@@ -29,7 +29,7 @@ import Prelude hiding (readFile, writeFile, appendFile, interact, getContents, g
 import Control.Exception (evaluate)
 import Control.Monad ((<=<))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import GHC.IO.Handle (Handle)

--- a/src/Data/Text/Internal/Encoding/Fusion.hs
+++ b/src/Data/Text/Internal/Encoding/Fusion.hs
@@ -38,7 +38,7 @@ module Data.Text.Internal.Encoding.Fusion
 import Control.Exception (assert)
 #endif
 import Data.Bits (shiftL, shiftR)
-import Data.ByteString.Internal (ByteString(..), mallocByteString, memcpy)
+import Data.ByteString.Internal (ByteString(..), mallocByteString)
 import Data.Text.Internal.Fusion (Step(..), Stream(..))
 import Data.Text.Internal.Fusion.Size
 import Data.Text.Encoding.Error
@@ -47,6 +47,7 @@ import Data.Text.Internal.Unsafe.Char (unsafeChr8, unsafeChr16, unsafeChr32)
 import Data.Text.Internal.Unsafe (unsafeWithForeignPtr)
 import Data.Word (Word8, Word16, Word32)
 import Foreign.ForeignPtr (ForeignPtr)
+import Foreign.Marshal.Utils (copyBytes)
 import Foreign.Storable (pokeByteOff)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Unsafe as B
@@ -197,7 +198,7 @@ unstream (Stream next s0 len) = unsafeDupablePerformIO $ do
           dest <- mallocByteString destLen
           unsafeWithForeignPtr src  $ \src'  ->
               unsafeWithForeignPtr dest $ \dest' ->
-                  memcpy dest' src' srcLen
+                  copyBytes dest' src' srcLen
           return dest
 
 decodeError :: forall s. String -> String -> OnDecodeError -> Maybe Word8

--- a/src/Data/Text/Internal/Lazy/Encoding/Fusion.hs
+++ b/src/Data/Text/Internal/Lazy/Encoding/Fusion.hs
@@ -49,8 +49,9 @@ import qualified Data.Text.Internal.Encoding.Utf16 as U16
 import qualified Data.Text.Internal.Encoding.Utf32 as U32
 import Data.Text.Unsafe (unsafeDupablePerformIO)
 import Foreign.ForeignPtr (ForeignPtr)
+import Foreign.Marshal.Utils (copyBytes)
 import Foreign.Storable (pokeByteOff)
-import Data.ByteString.Internal (mallocByteString, memcpy)
+import Data.ByteString.Internal (mallocByteString)
 #if defined(ASSERTS)
 import Control.Exception (assert)
 #endif
@@ -308,7 +309,7 @@ unstreamChunks chunkSize (Stream next s0 len0) = chunk s0 (upperBound 4 len0)
                 dest <- mallocByteString destLen
                 unsafeWithForeignPtr src  $ \src'  ->
                     unsafeWithForeignPtr dest $ \dest' ->
-                        memcpy dest' src' srcLen
+                        copyBytes dest' src' srcLen
                 return dest
 
 -- | /O(n)/ Convert a 'Stream' 'Word8' to a lazy 'ByteString'.

--- a/text.cabal
+++ b/text.cabal
@@ -189,7 +189,7 @@ library
     array            >= 0.3 && < 0.6,
     base             >= 4.10 && < 5,
     binary           >= 0.5 && < 0.9,
-    bytestring       >= 0.10.4 && < 0.12,
+    bytestring       >= 0.10.4 && < 0.13,
     deepseq          >= 1.1 && < 1.5,
     ghc-prim         >= 0.2 && < 0.11,
     template-haskell >= 2.5 && < 2.21


### PR DESCRIPTION
This is rather urgent as it blocks https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10823.