### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -16,7 +16,7 @@ jobs:
     - name: install deps
       run: |
         yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs ncurses-devel xz perl libstdc++-static
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=9.2.8 sh
     - uses: actions/checkout@v3
     - name: Test
       run: |

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         apt-get update -y
         apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl libncurses5 libtinfo5 libncurses5-dev libtinfo-dev
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
     - uses: actions/checkout@v1
     - name: Test
       run: |


### PR DESCRIPTION
In response to CI failures at https://github.com/haskell/text/pull/536:
* There is no stack-2.11 for i386, thus explicitly asking ghcup not install any.
* GHC 9.4.7 seems off on CentOS. Not our problem, let's stick to 9.2 series.