### PR TITLE
Add foldlM

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -103,6 +103,7 @@ module Data.Text
     , foldr
     , foldr'
     , foldr1
+    , foldlM
 
     -- ** Special folds
     , concat
@@ -993,6 +994,11 @@ foldl1 f t = S.foldl1 f (stream t)
 foldl1' :: HasCallStack => (Char -> Char -> Char) -> Text -> Char
 foldl1' f t = S.foldl1' f (stream t)
 {-# INLINE foldl1' #-}
+
+-- | /O(n)/ A monadic version of 'foldl'.
+foldlM :: Monad m => (a -> Char -> m a) -> a -> Text -> m a
+foldlM f z t = S.foldlM f z (stream t)
+{-# INLINE foldlM #-}
 
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -103,7 +103,7 @@ module Data.Text
     , foldr
     , foldr'
     , foldr1
-    , foldlM
+    , foldlM'
 
     -- ** Special folds
     , concat
@@ -995,10 +995,10 @@ foldl1' :: HasCallStack => (Char -> Char -> Char) -> Text -> Char
 foldl1' f t = S.foldl1' f (stream t)
 {-# INLINE foldl1' #-}
 
--- | /O(n)/ A monadic version of 'foldl'.
-foldlM :: Monad m => (a -> Char -> m a) -> a -> Text -> m a
-foldlM f z t = S.foldlM f z (stream t)
-{-# INLINE foldlM #-}
+-- | /O(n)/ A monadic version of 'foldl''.
+foldlM' :: Monad m => (a -> Char -> m a) -> a -> Text -> m a
+foldlM' f z t = S.foldlM' f z (stream t)
+{-# INLINE foldlM' #-}
 
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',

--- a/src/Data/Text/Internal/Fusion/Common.hs
+++ b/src/Data/Text/Internal/Fusion/Common.hs
@@ -77,6 +77,7 @@ module Data.Text.Internal.Fusion.Common
     , foldl1'
     , foldr
     , foldr1
+    , foldlM
 
     -- ** Special folds
     , concat
@@ -688,6 +689,20 @@ foldl1' f (Stream next s0 _len) = loop0_foldl1' s0
                              Skip s' -> loop_foldl1' z s'
                              Yield x s' -> loop_foldl1' (f z x) s'
 {-# INLINE [0] foldl1' #-}
+
+-- | A monadic version of foldl.
+--
+-- __Properties__
+--
+-- @ 'foldlM' f z0 . 'Data.Text.Internal.Fusion.stream' = 'Data.Text.foldlM' f z0 @
+foldlM :: P.Monad m => (b -> Char -> m b) -> b -> Stream Char -> m b
+foldlM f z0 (Stream next s0 _len) = loop_foldlM z0 s0
+    where
+      loop_foldlM !z !s = case next s of
+                            Done -> P.pure z
+                            Skip s' -> loop_foldlM z s'
+                            Yield x s' -> f z x P.>>= \z' -> loop_foldlM z' s'
+{-# INLINE [0] foldlM #-}
 
 -- | 'foldr', applied to a binary operator, a starting value (typically the
 -- right-identity of the operator), and a stream, reduces the stream using the

--- a/src/Data/Text/Internal/Fusion/Common.hs
+++ b/src/Data/Text/Internal/Fusion/Common.hs
@@ -77,7 +77,7 @@ module Data.Text.Internal.Fusion.Common
     , foldl1'
     , foldr
     , foldr1
-    , foldlM
+    , foldlM'
 
     -- ** Special folds
     , concat
@@ -690,19 +690,19 @@ foldl1' f (Stream next s0 _len) = loop0_foldl1' s0
                              Yield x s' -> loop_foldl1' (f z x) s'
 {-# INLINE [0] foldl1' #-}
 
--- | A monadic version of foldl.
+-- | A monadic version of 'foldl'.
 --
 -- __Properties__
 --
--- @ 'foldlM' f z0 . 'Data.Text.Internal.Fusion.stream' = 'Data.Text.foldlM' f z0 @
-foldlM :: P.Monad m => (b -> Char -> m b) -> b -> Stream Char -> m b
-foldlM f z0 (Stream next s0 _len) = loop_foldlM z0 s0
+-- @ 'foldlM'' f z0 . 'Data.Text.Internal.Fusion.stream' = 'Data.Text.foldlM'' f z0 @
+foldlM' :: P.Monad m => (b -> Char -> m b) -> b -> Stream Char -> m b
+foldlM' f z0 (Stream next s0 _len) = loop_foldlM' z0 s0
     where
-      loop_foldlM !z !s = case next s of
+      loop_foldlM' !z !s = case next s of
                             Done -> P.pure z
-                            Skip s' -> loop_foldlM z s'
-                            Yield x s' -> f z x P.>>= \z' -> loop_foldlM z' s'
-{-# INLINE [0] foldlM #-}
+                            Skip s' -> loop_foldlM' z s'
+                            Yield x s' -> f z x P.>>= \z' -> loop_foldlM' z' s'
+{-# INLINE [0] foldlM' #-}
 
 -- | 'foldr', applied to a binary operator, a starting value (typically the
 -- right-identity of the operator), and a stream, reduces the stream using the

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -101,6 +101,7 @@ module Data.Text.Lazy
     , foldl1'
     , foldr
     , foldr1
+    , foldlM
 
     -- ** Special folds
     , concat
@@ -814,6 +815,12 @@ foldl1 f t = S.foldl1 f (stream t)
 foldl1' :: HasCallStack => (Char -> Char -> Char) -> Text -> Char
 foldl1' f t = S.foldl1' f (stream t)
 {-# INLINE foldl1' #-}
+
+-- | /O(n)/ A monadic version of 'foldl'.
+--
+foldlM :: Monad m => (a -> Char -> m a) -> a -> Text -> m a
+foldlM f z t = S.foldlM f z (stream t)
+{-# INLINE foldlM #-}
 
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -101,7 +101,7 @@ module Data.Text.Lazy
     , foldl1'
     , foldr
     , foldr1
-    , foldlM
+    , foldlM'
 
     -- ** Special folds
     , concat
@@ -816,11 +816,11 @@ foldl1' :: HasCallStack => (Char -> Char -> Char) -> Text -> Char
 foldl1' f t = S.foldl1' f (stream t)
 {-# INLINE foldl1' #-}
 
--- | /O(n)/ A monadic version of 'foldl'.
+-- | /O(n)/ A monadic version of 'foldl''.
 --
-foldlM :: Monad m => (a -> Char -> m a) -> a -> Text -> m a
-foldlM f z t = S.foldlM f z (stream t)
-{-# INLINE foldlM #-}
+foldlM' :: Monad m => (a -> Char -> m a) -> a -> Text -> m a
+foldlM' f z t = S.foldlM' f z (stream t)
+{-# INLINE foldlM' #-}
 
 -- | /O(n)/ 'foldr', applied to a binary operator, a starting value
 -- (typically the right-identity of the operator), and a 'Text',


### PR DESCRIPTION
I haven't added tests or benchmarks yet, because I'm not quite sure how to do it. 

Open questions:

* Can QuickCheck generate monadic functions? 
* And what would be a good benchmark?
* Do we need a strict `foldlM'`?
* Why are the `Data.Text.Internal.Fusion.Common` folds marked `INLINE [0]`?

For motivation, see [this recent stackoverflow question](https://stackoverflow.com/questions/77385819/how-to-convert-text-to-vector-without-extraneous-allocations#77390907). There the problem is to convert a text into a vector of characters, but that requires extraneous allocation if done naively with `unfoldr Text.uncons`. If a `foldlM` function were exposed like I implemented in this PR then you can write it efficiently like this:

```haskell
import Data.Text as T
import qualified Data.Vector.Unboxed as VU
import qualified Data.Vector.Unboxed.Mutable as VUM
import Test.Tasty.Bench

createFoldMethod :: Text -> VU.Vector Char
createFoldMethod t = VU.create $ do
  m <- VUM.new (T.length t)
  _ <- T.foldlM (\i x -> VUM.write m i x *> pure (i + 1)) 0 t
  pure m

main = defaultMain
  [ bench (show (10 ^ i) ++ " characters") $ whnf createFoldMethod $ T.replicate (10 ^ i) (T.pack "0")
  | i <- [1..5]
  ]
```

Benchmark results:

```
  10 characters:     OK
    33.1 ns ± 2.7 ns, 111 B  allocated,   0 B  copied, 6.0 MB peak memory
  100 characters:    OK
    228  ns ±  21 ns, 471 B  allocated,   0 B  copied, 6.0 MB peak memory
  1000 characters:   OK
    2.16 μs ± 169 ns, 3.9 KB allocated,   0 B  copied,  10 MB peak memory
  10000 characters:  OK
    21.0 μs ± 1.7 μs,  39 KB allocated,   2 B  copied,  10 MB peak memory
  100000 characters: OK
    210  μs ±  15 μs, 386 KB allocated,  21 B  copied,  11 MB peak memory
```

This matches the performance of an implementation I wrote that loops over the internal stream representation manually.