### PR TITLE
Remove accidentally committed dump pragmas

### DIFF
--- a/src/Data/Text/Internal/Reverse.hs
+++ b/src/Data/Text/Internal/Reverse.hs
@@ -8,8 +8,6 @@
 
 {-# OPTIONS_HADDOCK not-home #-}
 
-{-# OPTIONS_GHC -ddump-to-file -ddump-simpl -dsuppress-all -dno-suppress-type-signatures #-}
-
 -- | Implements 'reverse', using efficient C routines by default.
 module Data.Text.Internal.Reverse (reverse) where
 


### PR DESCRIPTION
Looks like these snuck in as part of https://github.com/haskell/text/pull/536