### PR TITLE
Add type synonyms for lazy and strict text flavours

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -53,6 +53,7 @@ module Data.Text
 
     -- * Types
       Text
+    , StrictText
 
     -- * Creation and elimination
     , pack
@@ -238,7 +239,7 @@ import qualified Data.Text.Internal.Fusion.Common as S
 import Data.Text.Encoding (decodeUtf8', encodeUtf8)
 import Data.Text.Internal.Fusion (stream, reverseStream, unstream)
 import Data.Text.Internal.Private (span_)
-import Data.Text.Internal (Text(..), empty, firstf, mul, safe, text, append, pack)
+import Data.Text.Internal (Text(..), StrictText, empty, firstf, mul, safe, text, append, pack)
 import Data.Text.Internal.Unsafe.Char (unsafeWrite, unsafeChr8)
 import Data.Text.Show (singleton, unpack, unpackCString#, unpackCStringAscii#)
 import qualified Prelude as P

--- a/src/Data/Text/Internal.hs
+++ b/src/Data/Text/Internal.hs
@@ -29,6 +29,7 @@ module Data.Text.Internal
     -- * Types
     -- $internals
       Text(..)
+    , StrictText
     -- * Construction
     , text
     , textP
@@ -67,6 +68,9 @@ data Text = Text
     {-# UNPACK #-} !Int     -- ^ offset in bytes (not in Char!), pointing to a start of UTF-8 sequence
     {-# UNPACK #-} !Int     -- ^ length in bytes (not in Char!), pointing to an end of UTF-8 sequence
     deriving (Typeable)
+
+-- | Type synonym for the strict flavour of 'Text'.
+type StrictText = Text
 
 -- | Smart constructor.
 text_ ::

--- a/src/Data/Text/Internal/Lazy.hs
+++ b/src/Data/Text/Internal/Lazy.hs
@@ -21,6 +21,7 @@
 module Data.Text.Internal.Lazy
     (
       Text(..)
+    , LazyText
     , chunk
     , empty
     , foldrChunks
@@ -50,6 +51,9 @@ import qualified Data.Text.Internal as T
 data Text = Empty
           | Chunk {-# UNPACK #-} !T.Text Text
             deriving (Typeable)
+
+-- | Type synonym for the lazy flavour of 'Text'.
+type LazyText = Text
 
 -- $invariant
 --

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -46,6 +46,7 @@ module Data.Text.Lazy
 
     -- * Types
       Text
+    , LazyText
 
     -- * Creation and elimination
     , pack
@@ -230,7 +231,7 @@ import qualified Data.Text.Internal.Lazy.Fusion as S
 import Data.Text.Internal.Fusion.Types (PairS(..))
 import Data.Text.Internal.Lazy.Fusion (stream, unstream)
 import Data.Text.Internal.Lazy (Text(..), chunk, empty, foldlChunks,
-                                foldrChunks, smallChunkSize, defaultChunkSize, equal)
+                                foldrChunks, smallChunkSize, defaultChunkSize, equal, LazyText)
 import Data.Text.Internal (firstf, safe, text)
 import Data.Text.Lazy.Encoding (decodeUtf8', encodeUtf8)
 import Data.Text.Internal.Lazy.Search (indices)

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -442,12 +442,12 @@ toChunks :: Text -> [T.Text]
 toChunks cs = foldrChunks (:) [] cs
 
 -- | /O(n)/ Convert a lazy 'Text' into a strict 'T.Text'.
-toStrict :: Text -> T.Text
+toStrict :: LazyText -> T.StrictText
 toStrict t = T.concat (toChunks t)
 {-# INLINE [1] toStrict #-}
 
 -- | /O(c)/ Convert a strict 'T.Text' into a lazy 'Text'.
-fromStrict :: T.Text -> Text
+fromStrict :: T.StrictText -> LazyText
 fromStrict t = chunk t Empty
 {-# INLINE [1] fromStrict #-}
 


### PR DESCRIPTION
This PR adds type synonyms for lazy and strict flavours of `Text`.

closes #317