### PR TITLE
Fix typo

### DIFF
--- a/src/Data/Text/Internal/Reverse.hs
+++ b/src/Data/Text/Internal/Reverse.hs
@@ -48,7 +48,7 @@ reverse t            = reverseNonEmpty t
 reverseNonEmpty ::
   Text -> Text
 #if defined(PURE_HASKELL)
-reverseNonEmtpy (Text src off len) = runST $ do
+reverseNonEmpty (Text src off len) = runST $ do
     dest <- A.new len
     _ <- reversePoints src off dest len
     result <- A.unsafeFreeze dest


### PR DESCRIPTION
This PR fixes a typo that can only be seen when the `PURE_HASKELL` flag is enabled.