### PR TITLE
Reenable -fpure-haskell

### DIFF
--- a/src/Data/Text/Internal/Transformation.hs
+++ b/src/Data/Text/Internal/Transformation.hs
@@ -34,9 +34,6 @@ import Prelude (Char, Bool(..), Int,
                 Monad(..), pure,
                 (+), (-), ($),
                 not, return, otherwise, IO)
-#if defined(ASSERTS)
-import Control.Exception (assert)
-#endif
 import Data.Bits ((.&.), shiftR, shiftL)
 import Control.Monad.ST (ST, runST)
 import Control.Monad.ST.Unsafe (unsafeIOToST)


### PR DESCRIPTION
The other implementation looks identical:

```haskell
reverseNonEmpty (Text (A.ByteArray ba) off len) = runST $ do
    marr@(A.MutableByteArray mba) <- A.new len
    unsafeIOToST $ c_reverse mba ba (fromIntegral off) (fromIntegral len)
    brr <- A.unsafeFreeze marr
    return $ Text brr 0 len
```