### PR TITLE
Pure-haskell "memchr"

### DIFF
--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -231,6 +231,7 @@ import Data.Binary (Binary(get, put))
 import Data.Monoid (Monoid(..))
 import Data.Semigroup (Semigroup(..))
 import Data.String (IsString(..))
+import Data.Text.Internal.ArrayUtils (memchr)
 import Data.Text.Internal.IsAscii (isAscii)
 import Data.Text.Internal.Reverse (reverse)
 import Data.Text.Internal.Measure (measure_off)
@@ -254,7 +255,7 @@ import qualified Data.Text.Lazy as L
 #endif
 import Data.Word (Word8)
 import Foreign.C.Types
-import GHC.Base (eqInt, neInt, gtInt, geInt, ltInt, leInt, ByteArray#)
+import GHC.Base (eqInt, neInt, gtInt, geInt, ltInt, leInt)
 import qualified GHC.Exts as Exts
 import GHC.Int (Int8)
 import GHC.Stack (HasCallStack)
@@ -1864,12 +1865,8 @@ lines (Text arr@(A.ByteArray arr#) off len) = go off
       | delta < 0 = [Text arr n (len + off - n)]
       | otherwise = Text arr n delta : go (n + delta + 1)
       where
-        delta = cSsizeToInt $
-          memchr arr# (intToCSize n) (intToCSize (len + off - n)) 0x0A
+        delta = memchr arr# n (len + off - n) 0x0A
 {-# INLINE lines #-}
-
-foreign import ccall unsafe "_hs_text_memchr" memchr
-    :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize
 
 -- | /O(n)/ Joins lines, after appending a terminating newline to
 -- each.

--- a/src/Data/Text/Internal/ArrayUtils.hs
+++ b/src/Data/Text/Internal/ArrayUtils.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnliftedFFITypes #-}
+{-# LANGUAGE CPP #-}
+
+module Data.Text.Internal.ArrayUtils (memchr) where
+
+#if defined(PURE_HASKELL)
+import qualified Data.Text.Array as A
+import Data.List (elemIndex)
+#else
+import Foreign.C.Types
+import System.Posix.Types (CSsize(..))
+#endif
+import GHC.Exts (ByteArray#)
+import Data.Word (Word8)
+
+memchr :: ByteArray# -> Int -> Int -> Word8 -> Int
+#if defined(PURE_HASKELL)
+memchr arr# off len w =
+    let tempBa = A.ByteArray arr#
+    in case elemIndex w (A.toList tempBa off len) of
+        Nothing -> -1
+        Just i -> i
+#else
+memchr arr# off len w = fromIntegral $ c_memchr arr# (intToCSize off) (intToCSize len) w
+
+intToCSize :: Int -> CSize
+intToCSize = fromIntegral
+
+
+foreign import ccall unsafe "_hs_text_memchr" c_memchr
+    :: ByteArray# -> CSize -> CSize -> Word8 -> CSsize
+#endif

--- a/text.cabal
+++ b/text.cabal
@@ -162,6 +162,7 @@ library
     Data.Text.IO
     Data.Text.IO.Utf8
     Data.Text.Internal
+    Data.Text.Internal.ArrayUtils
     Data.Text.Internal.Builder
     Data.Text.Internal.Builder.Functions
     Data.Text.Internal.Builder.Int.Digits

--- a/text.cabal
+++ b/text.cabal
@@ -96,7 +96,6 @@ flag pure-haskell
 library
   if arch(javascript) || flag(pure-haskell)
     cpp-options: -DPURE_HASKELL
-    c-sources:  cbits/utils.c
   else
     c-sources:  cbits/is_ascii.c
                 cbits/measure_off.c


### PR DESCRIPTION
This removes use of utils.c under -fpure-haskell.

(Technically there is still one use site of _hs_text_memcmp2,  but it's guarded by MIN_VERSION_BASE(4,11,0). Thus -fpure-haskell is not compatible with ghc-8.2. I think I'm ok with that.)

This PR will conflict with #545 , so I'll keep this one a draft until that one is finalized. Plus, my use of `toList` is probably dumb, and I'd like to come up with a better way of doing it.