### PR TITLE
Prepare text-2.1.1 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+### 2.1.1
+
+* Add pure Haskell implementations as an alternative to C-based ones,
+  suitable for JavaScript backend.
+
+* [Add type synonyms for lazy and strict text flavours](https://github.com/haskell/text/pull/547)
+
+* [Share empty `Text` values](https://github.com/haskell/text/pull/493)
+
+* [Fix bug in `isValidUtf8ByteArray`](https://github.com/haskell/text/pull/553)
+
+* [Optimize the implementation of `Data.Text.concat`](https://github.com/haskell/text/pull/551)
+
+* [Fix `filter/filter` rules for `Text` and lazy `Text`](https://github.com/haskell/text/pull/560)
+
 ### 2.1
 
 * [Switch `Data.Text.Array` to `Data.Array.Byte`](https://github.com/haskell/text/pull/474)

--- a/src/Data/Text/Internal/Encoding.hs
+++ b/src/Data/Text/Internal/Encoding.hs
@@ -244,8 +244,10 @@ validateUtf8Chunk bs = validateUtf8ChunkFrom 0 bs (,)
 {-# INLINE validateUtf8ChunkFrom #-}
 validateUtf8ChunkFrom :: forall r. Int -> ByteString -> (Int -> Maybe Utf8State -> r) -> r
 validateUtf8ChunkFrom ofs bs k
-  -- B.isValidUtf8 is buggy before bytestring-0.11.5.0
-#if defined(SIMDUTF) || MIN_VERSION_bytestring(0,11,5)
+  -- B.isValidUtf8 is buggy before bytestring-0.11.5.3 / bytestring-0.12.1.0.
+  -- MIN_VERSION_bytestring does not allow us to differentiate
+  -- between 0.11.5.2 and 0.11.5.3 so no choice except demanding 0.12.1+.
+#if defined(SIMDUTF) || MIN_VERSION_bytestring(0,12,1)
   | guessUtf8Boundary > 0 &&
     -- the rest of the bytestring is valid utf-8 up to the boundary
     (

--- a/src/Data/Text/Internal/Validate.hs
+++ b/src/Data/Text/Internal/Validate.hs
@@ -47,7 +47,10 @@ isValidUtf8ByteString :: ByteString -> Bool
 isValidUtf8ByteString bs = withBS bs $ \fp len -> unsafeDupablePerformIO $
   unsafeWithForeignPtr fp $ \ptr -> (/= 0) <$> c_is_valid_utf8_ptr_unsafe ptr (fromIntegral len)
 #else
-#if MIN_VERSION_bytestring(0,11,2)
+-- B.isValidUtf8 is buggy before bytestring-0.11.5.3 / bytestring-0.12.1.0.
+-- MIN_VERSION_bytestring does not allow us to differentiate
+-- between 0.11.5.2 and 0.11.5.3 so no choice except demanding 0.12.1+.
+#if MIN_VERSION_bytestring(0,12,1)
 isValidUtf8ByteString = B.isValidUtf8
 #else
 isValidUtf8ByteString = N.isValidUtf8ByteStringHaskell

--- a/text.cabal
+++ b/text.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           text
-version:        2.1
+version:        2.1.1
 
 homepage:       https://github.com/haskell/text
 bug-reports:    https://github.com/haskell/text/issues


### PR DESCRIPTION
As urged by @wz1000 at https://gitlab.haskell.org/ghc/ghc/-/issues/24079#note_548327, let's make a release of `text-2.1.1` asap. 