### PR TITLE
Don't try to use AVX512 without OS support

### DIFF
--- a/cbits/measure_off.c
+++ b/cbits/measure_off.c
@@ -44,12 +44,16 @@
 bool has_avx512_vl_bw() {
 #if (__GNUC__ >= 7 || __GNUC__ == 6 && __GNUC_MINOR__ >= 3) || defined(__clang_major__)
   uint32_t eax = 0, ebx = 0, ecx = 0, edx = 0;
+  uint64_t xcr0;
   __get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx);
   // https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features
+  __asm__("xgetbv\n\t" : "=a" (xcr0) : "c" (0));
   const bool has_avx512_bw = ebx & (1 << 30);
   const bool has_avx512_vl = ebx & (1 << 31);
+  // XCR0 bits 5, 6, and 7
+  const bool avx512_os_enabled = (xcr0 & 0xE0) == 0xE0;
   // printf("cpuid=%d=cpuid\n", has_avx512_bw && has_avx512_vl);
-  return has_avx512_bw && has_avx512_vl;
+  return has_avx512_bw && has_avx512_vl && avx512_os_enabled;
 #else
   return false;
 #endif


### PR DESCRIPTION
AVX512 instructions require OS support as well as CPU support. Bits 5, 6, and 7 of XCR0 should be enabled to run with AVX512 support. This fixes SIGILL on OpenBSD, for example.

[OpenBSD ports commit with identical patch](https://github.com/openbsd/ports/commit/bb29df359f152890503a01cd3157eeb0e9701c9d)

Required alongside the similar fix to simdutf pulled in by #564 for text to work right on OpenBSD when the processor flags AVX512 support.
