### PR TITLE
ci: Use haskell-actions/setup (moved from haskell/actions/setup)

### DIFF
--- a/.github/workflows/developer-flag.yml
+++ b/.github/workflows/developer-flag.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/simdutf-flag-windows.yml
+++ b/.github/workflows/simdutf-flag-windows.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/simdutf-flag.yml
+++ b/.github/workflows/simdutf-flag.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/windows_and_macOS.yml
+++ b/.github/workflows/windows_and_macOS.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -29,7 +29,7 @@ jobs:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}
     # We rebuild tests several times to avoid intermittent failures on Windows
-    # https://github.com/haskell/actions/issues/36
+    # https://github.com/haskell-actions/issues/36
     - name: Test
       run: |
         bld() { cabal build pkg:text:tests; }

--- a/.github/workflows/windows_and_macOS.yml
+++ b/.github/workflows/windows_and_macOS.yml
@@ -28,12 +28,9 @@ jobs:
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}
-    # We rebuild tests several times to avoid intermittent failures on Windows
-    # https://github.com/haskell-actions/issues/36
     - name: Test
       run: |
-        bld() { cabal build pkg:text:tests; }
-        bld || bld || bld
+        cabal build pkg:text:tests
         cabal test
     - name: Haddock
       run: cabal haddock


### PR DESCRIPTION
I saw the deprecation message in the logs. Also visible on the archived repo https://github.com/haskell/actions