### PR TITLE
Disable x-partial warnings in tests (uses of head and tail)

### DIFF
--- a/tests/Tests/Properties/Basics.hs
+++ b/tests/Tests/Properties/Basics.hs
@@ -4,6 +4,7 @@
 
 {-# OPTIONS_GHC -Wno-missing-signatures    #-}
 {-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+{-# OPTIONS_GHC -Wno-x-partial #-}
 
 module Tests.Properties.Basics
     ( testBasics

--- a/tests/Tests/ShareEmpty.hs
+++ b/tests/Tests/ShareEmpty.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-x-partial #-}
 
 module Tests.ShareEmpty
   ( tests


### PR DESCRIPTION
Those new warnings added in GHC 9.8. The uses in the test suite are either safe or explicitly intended to test the error case (via `=^=` in `tests/Tests/Utils.hs`).


Here are the relevant build logs that this PR hides:

```

tests/Tests/ShareEmpty.hs:110:60: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘head’
    (imported from Data.List, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
    |
110 |   , testCase "inits _ = [empty, ...]" $ assertPtrEqEmpty $ L.head $ T.inits "123"
    |                                                            ^^^^^^

tests/Tests/Properties/Basics.hs:62:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
62 | s_head            = head   `eqP` S.head
   |                     ^^^^

tests/Tests/Properties/Basics.hs:63:28: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
63 | sf_head (applyFun -> p) = (head . L.filter p) `eqP` (S.head . S.filter p)
   |                            ^^^^

tests/Tests/Properties/Basics.hs:64:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
64 | t_head            = head   `eqP` T.head
   |                     ^^^^

tests/Tests/Properties/Basics.hs:65:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘head’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
65 | tl_head           = head   `eqP` TL.head
   |                     ^^^^

tests/Tests/Properties/Basics.hs:70:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘tail’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Replace it with drop 1, or use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
70 | s_tail            = tail   `eqP` (unpackS . S.tail)
   |                     ^^^^

tests/Tests/Properties/Basics.hs:71:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘tail’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Replace it with drop 1, or use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
71 | s_tail_s          = tail   `eqP` (unpackS . S.unstream . S.tail)
   |                     ^^^^

tests/Tests/Properties/Basics.hs:72:28: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘tail’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Replace it with drop 1, or use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
72 | sf_tail (applyFun -> p) = (tail . L.filter p) `eqP` (unpackS . S.tail . S.filter p)
   |                            ^^^^

tests/Tests/Properties/Basics.hs:73:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘tail’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Replace it with drop 1, or use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
73 | t_tail            = tail   `eqP` (unpackS . T.tail)
   |                     ^^^^

tests/Tests/Properties/Basics.hs:74:21: warning: [GHC-63394] [-Wx-partial]
Warning:     In the use of ‘tail’
    (imported from Prelude, but defined in GHC.List):
    "This is a partial function, it throws an error on empty lists. Replace it with drop 1, or use pattern matching or Data.List.uncons instead. Consider refactoring to use Data.List.NonEmpty."
   |
74 | tl_tail           = tail   `eqP` (unpackS . TL.tail)
   |                     ^^^^
```