### PR TITLE
Make fromString INLINEABLE

### DIFF
--- a/src/Data/Text/Internal/Builder.hs
+++ b/src/Data/Text/Internal/Builder.hs
@@ -209,7 +209,7 @@ fromString str = Builder $ \k (Buffer p0 o0 u0 l0) ->
     in loop p0 o0 u0 l0 str
   where
     chunkSize = smallChunkSize
-{-# INLINE fromString #-}
+{-# INLINEABLE fromString #-}
 
 -- | /O(1)./ A @Builder@ taking a lazy @Text@, satisfying
 --


### PR DESCRIPTION
Closes #549 

The generated Core for `f = "a cat" <> "a dog" <> "a fish" :: Data.Text.Lazy.Builder` is now more reasonable:

```
f = "a cat"#

f1 = unpackCString# f

f2 = "a dog"#

f3 = unpackCString# f2

f4 = "a fish"#

f5 = unpackCString# f4

$wf
  = \ @s x ww ww1 ww2 ww3 eta ->
      let {
        lvl
          = \ ds eta1 ->
              case ds of { Buffer ww4 ww5 ww6 ww7 ->
              $wfromString f5 x ww4 ww5 ww6 ww7 eta1
              } } in
      $wfromString
        f1
        ((\ eta1 eta2 ->
            case eta1 of { Buffer ww4 ww5 ww6 ww7 ->
            $wfromString f3 (lvl `cast` <Co:9> :: ...) ww4 ww5 ww6 ww7 eta2
            })
         `cast` <Co:9> :: ...)
        ww
        ww1
        ww2
        ww3
        eta
```