### PR TITLE
Improve lazy performance of `Data.Text.Lazy.inits`

### DIFF
--- a/benchmarks/haskell/Benchmarks.hs
+++ b/benchmarks/haskell/Benchmarks.hs
@@ -20,6 +20,7 @@ import qualified Benchmarks.EncodeUtf8 as EncodeUtf8
 import qualified Benchmarks.Equality as Equality
 import qualified Benchmarks.FileRead as FileRead
 import qualified Benchmarks.FoldLines as FoldLines
+import qualified Benchmarks.Micro as Micro
 import qualified Benchmarks.Multilang as Multilang
 import qualified Benchmarks.Pure as Pure
 import qualified Benchmarks.ReadNumbers as ReadNumbers
@@ -61,6 +62,7 @@ main = do
     defaultMain
         [ Builder.benchmark
         , Concat.benchmark
+        , Micro.benchmark
         , bgroup "DecodeUtf8"
             [ env (DecodeUtf8.initEnv (tf "libya-chinese.html")) (DecodeUtf8.benchmark "html")
             , env (DecodeUtf8.initEnv (tf "yiwiki.xml")) (DecodeUtf8.benchmark "xml")

--- a/benchmarks/haskell/Benchmarks/Micro.hs
+++ b/benchmarks/haskell/Benchmarks/Micro.hs
@@ -4,19 +4,29 @@ module Benchmarks.Micro (benchmark) where
 
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text as T
-import Test.Tasty.Bench (Benchmark, bgroup, bench, nf)
+import Test.Tasty.Bench (Benchmark, Benchmarkable, bgroup, bcompareWithin, bench, nf)
 
 benchmark :: Benchmark
 benchmark = bgroup "Micro"
-  [ -- Accessing i-th element should take O(i) time.
-    -- The 2k case should run in 2x the time of the 1k case.
-    bgroup "Lazy.inits"
-      [ bench "last 1k" $ nf (last . TL.inits) (chunks 1000)
-      , bench "last 2k" $ nf (last . TL.inits) (chunks 2000)
-      , bench "map-take1 1k" $ nf (map (TL.take 1) . TL.inits) (chunks 1000)
-      , bench "map-take1 2k" $ nf (map (TL.take 1) . TL.inits) (chunks 2000)
-      ]
+  [ blinear "lazy-inits--last" 500000 2 0.1 $ \len ->
+      nf (last . TL.inits) (chunks len)
+  , blinear "lazy-inits--map-take1" 500000 2 0.1 $ \len ->
+      nf (map (TL.take 1) . TL.inits) (chunks len)
   ]
 
 chunks :: Int -> TL.Text
 chunks n = TL.fromChunks (replicate n (T.pack "a"))
+
+-- Check that running an action with input length (m * baseLen)
+-- runs m times slower than the same action with input length baseLen.
+blinear :: String  -- ^ Name (must be globally unique!)
+        -> Int     -- ^ Base length
+        -> Int     -- ^ Multiplier m
+        -> Double  -- ^ Slack s
+        -> (Int -> Benchmarkable)  -- ^ Action to measure, parameterized by input length
+        -> Benchmark
+blinear name baseLen m s run = bgroup name
+  [ bench "baseline" $ run baseLen
+  , bcompareWithin (fromIntegral m * (1 - s)) (fromIntegral m * (1 + s)) (name ++ ".baseline") $
+      bench ("x" ++ show m) $ run (m * baseLen)
+  ]

--- a/benchmarks/haskell/Benchmarks/Micro.hs
+++ b/benchmarks/haskell/Benchmarks/Micro.hs
@@ -1,0 +1,22 @@
+-- | Benchmarks on artificial data. 
+
+module Benchmarks.Micro (benchmark) where
+
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
+import Test.Tasty.Bench (Benchmark, bgroup, bench, nf)
+
+benchmark :: Benchmark
+benchmark = bgroup "Micro"
+  [ -- Accessing i-th element should take O(i) time.
+    -- The 2k case should run in 2x the time of the 1k case.
+    bgroup "Lazy.inits"
+      [ bench "last 1k" $ nf (last . TL.inits) (chunks 1000)
+      , bench "last 2k" $ nf (last . TL.inits) (chunks 2000)
+      , bench "map-take1 1k" $ nf (map (TL.take 1) . TL.inits) (chunks 1000)
+      , bench "map-take1 2k" $ nf (map (TL.take 1) . TL.inits) (chunks 2000)
+      ]
+  ]
+
+chunks :: Int -> TL.Text
+chunks n = TL.fromChunks (replicate n (T.pack "a"))

--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -1448,9 +1448,9 @@ initsNE ts0 = Empty NE.:| inits' 0 ts0
     inits' :: Int64  -- Number of previous chunks i
            -> Text   -- The remainder after dropping i chunks from ts0
            -> [Text] -- Prefixes longer than the first i chunks of ts0.
-    inits' _ Empty        = []
-    inits' i (Chunk t ts) = L.map (takeChunks i ts0) (NE.tail (T.initsNE t))
-                            ++ inits' (i + 1) ts
+    inits' !i (Chunk t ts) = L.map (takeChunks i ts0) (NE.tail (T.initsNE t))
+                          ++ inits' (i + 1) ts
+    inits' _ Empty         = []
 
 takeChunks :: Int64 -> Text -> T.Text -> Text
 takeChunks !i (Chunk t ts) lastChunk | i > 0 = Chunk t (takeChunks (i - 1) ts lastChunk)

--- a/text.cabal
+++ b/text.cabal
@@ -333,6 +333,7 @@ benchmark text-benchmarks
     Benchmarks.Equality
     Benchmarks.FileRead
     Benchmarks.FoldLines
+    Benchmarks.Micro
     Benchmarks.Multilang
     Benchmarks.Programs.BigTable
     Benchmarks.Programs.Cut


### PR DESCRIPTION
Closes #562

The previous implementation, itself based on an earlier version of `Data.List.inits`, inherited the flaw that accessing the i-th element took quadratic time O(i²). This now takes linear time O(i) as expected.

The current version of `Data.List.inits` uses a banker's queue to obtain good performance when generating very long lists. For lazy text, consisting of a few big chunks, that benefit seems negligible. So I chose a simpler implementation.

Benchmarks included.

Quadratic growth before (the "2k" benchmarks take 4x the time of the "1k" benchmarks):

```
    Lazy.inits
      last 1k:      OK
        9.19 ms ± 475 μs
      last 2k:      OK
        46.7 ms ± 1.5 ms
      map-take1 1k: OK
        8.99 ms ± 798 μs
      map-take1 2k: OK
        47.0 ms ± 1.8 ms
```

Linear growth after (the "2k" benchmarks take twice the time of the "1k" benchmarks):

```
Lazy.inits
      last 1k:      OK
        46.8 μs ± 3.7 μs
      last 2k:      OK
        94.6 μs ± 1.8 μs
      map-take1 1k: OK
        66.7 μs ± 688 ns
      map-take1 2k: OK
        132  μs ± 6.2 μs
```