### PR TITLE
Data.Text.IO.Utf8: use B.putStrLn instead of B.putStr t >> B.putStr "\n"

### DIFF
--- a/src/Data/Text/IO/Utf8.hs
+++ b/src/Data/Text/IO/Utf8.hs
@@ -25,15 +25,16 @@ module Data.Text.IO.Utf8
     , putStrLn
     ) where
 
-import Prelude hiding (readFile, writeFile, appendFile, interact, getContents, getLine, putStr, putStrLn)
+import Prelude ()
 import Control.Exception (evaluate)
-import Control.Monad ((<=<))
+import Control.Monad ((<=<), (=<<))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
+import Data.Function ((.))
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import GHC.IO.Handle (Handle)
-import qualified Data.ByteString.Char8 as B.Char8
+import System.IO (IO, FilePath)
 
 decodeUtf8IO :: ByteString -> IO Text
 decodeUtf8IO = evaluate . decodeUtf8
@@ -67,7 +68,7 @@ hPutStr h = B.hPutStr h . encodeUtf8
 
 -- | Write a string to a handle, followed by a newline.
 hPutStrLn :: Handle -> Text -> IO ()
-hPutStrLn h t = hPutStr h t >> B.hPutStr h (B.Char8.singleton '\n')
+hPutStrLn h = B.hPutStrLn h . encodeUtf8
 
 -- | The 'interact' function takes a function of type @Text -> Text@
 -- as its argument. The entire input from the standard input device is
@@ -90,4 +91,4 @@ putStr = B.putStr . encodeUtf8
 
 -- | Write a string to 'stdout', followed by a newline.
 putStrLn :: Text -> IO ()
-putStrLn t = B.putStr (encodeUtf8 t) >> B.putStr (B.Char8.singleton '\n')
+putStrLn = B.putStrLn . encodeUtf8


### PR DESCRIPTION
This is not just a stylistic change: it also improves atomicity of `putStrLn` in concurrent environment, when multiple threads attempt to execute it at once. See https://www.snoyman.com/blog/2016/11/haskells-missing-concurrency-basics/

(Now `B.putStrLn` is not perfect either, but that's the problem to solve in `bytestring`)