### PR TITLE
Feature: `sconcat` and `stimes`.

### DIFF
--- a/benchmarks/haskell/Benchmarks/Pure.hs
+++ b/benchmarks/haskell/Benchmarks/Pure.hs
@@ -26,6 +26,8 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
 import qualified Data.Text.Lazy.Encoding as TL
+import Data.Semigroup
+import Data.List.NonEmpty (NonEmpty((:|)))
 
 data Env = Env
     { bsa :: !BS.ByteString
@@ -82,6 +84,14 @@ benchmark kind ~Env{..} =
         , bgroup "concat"
             [ benchT   $ nf T.concat tl
             , benchTL  $ nf TL.concat tll
+            ]
+        , bgroup "sconcat"
+            [ benchT   $ nf sconcat (T.empty :| tl)
+            , benchTL  $ nf sconcat (TL.empty :| tll)
+            ]
+        , bgroup "stimes"
+            [ benchT   $ nf (stimes (10 :: Int)) ta
+            , benchTL  $ nf (stimes (10 :: Int)) tla
             ]
         , bgroup "cons"
             [ benchT   $ nf (T.cons c) ta

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -370,11 +370,12 @@ instance Read Text where
     readsPrec p str = [(pack x,y) | (x,y) <- readsPrec p str]
 
 -- | @since 1.2.2.0
+--
+-- Beware: @stimes@ will crash if the given number does not fit into
+-- an @Int@.
 instance Semigroup Text where
     (<>) = append
 
-    -- | Beware: this function will evaluate to error if the given number does
-    -- not fit into an @Int@.
     stimes howManyTimes
       | howManyTimes < 0 = P.error "Data.Text.stimes: given number is negative!"
       | otherwise =

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -372,6 +372,8 @@ instance Read Text where
 -- | @since 1.2.2.0
 instance Semigroup Text where
     (<>) = append
+    stimes = replicate . P.fromIntegral
+    sconcat = concat . NonEmptyList.toList
 
 instance Monoid Text where
     mempty  = empty

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -272,8 +272,7 @@ import Data.Word (Word8)
 import Foreign.C.Types
 import GHC.Base (eqInt, neInt, gtInt, geInt, ltInt, leInt)
 import qualified GHC.Exts as Exts
-import GHC.Int (Int8, Int (I#))
-import GHC.Num.Integer (Integer(IS, IP, IN))
+import GHC.Int (Int8)
 import GHC.Stack (HasCallStack)
 import qualified Language.Haskell.TH.Lib as TH
 import qualified Language.Haskell.TH.Syntax as TH
@@ -376,10 +375,11 @@ instance Semigroup Text where
 
     -- | Beware: this function will evaluate to error if the given number does
     -- not fit into an @Int@.
-    stimes howManyTimes = case P.toInteger howManyTimes of
-      IS howManyTimesInt# -> replicate (I# howManyTimesInt#)
-      IP _ -> P.error "Data.Text.stimes: given number does not fit into an Int!"
-      IN _ -> P.const empty
+    stimes howManyTimes =
+        let howManyTimesInt = P.fromIntegral howManyTimes :: Int
+        in  if P.fromIntegral howManyTimesInt == howManyTimes
+            then replicate howManyTimesInt
+            else P.error "Data.Text.stimes: given number does not fit into an Int!"
 
     sconcat = concat . NonEmptyList.toList
 

--- a/src/Data/Text.hs
+++ b/src/Data/Text.hs
@@ -375,7 +375,9 @@ instance Semigroup Text where
 
     -- | Beware: this function will evaluate to error if the given number does
     -- not fit into an @Int@.
-    stimes howManyTimes =
+    stimes howManyTimes
+      | howManyTimes < 0 = P.error "Data.Text.stimes: given number is negative!"
+      | otherwise =
         let howManyTimesInt = P.fromIntegral howManyTimes :: Int
         in  if P.fromIntegral howManyTimesInt == howManyTimes
             then replicate howManyTimesInt

--- a/tests/Tests/Properties.hs
+++ b/tests/Tests/Properties.hs
@@ -17,6 +17,7 @@ import Tests.Properties.Read (testRead)
 import Tests.Properties.Text (testText)
 import Tests.Properties.Transcoding (testTranscoding)
 import Tests.Properties.Validate (testValidate)
+import Tests.Properties.CornerCases (testCornerCases)
 
 tests :: TestTree
 tests =
@@ -30,5 +31,6 @@ tests =
     testBuilder,
     testLowLevel,
     testRead,
+    testCornerCases,
     testValidate
   ]

--- a/tests/Tests/Properties/CornerCases.hs
+++ b/tests/Tests/Properties/CornerCases.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Check that the definitions that are partial crash in the expected ways or
+-- return sensible defaults.
+module Tests.Properties.CornerCases (testCornerCases) where
+
+import Control.Exception
+import Data.Either
+import Data.Semigroup
+import Data.Text
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Tests.QuickCheckUtils ()
+
+testCornerCases :: TestTree
+testCornerCases =
+  testGroup
+    "corner cases"
+    [ testGroup
+        "stimes"
+        $ let specimen = stimes :: Integer -> Text -> Text
+          in  [ testProperty
+                  "given a negative number, return empty text"
+                  $ \(Negative number) text -> specimen number text == ""
+              , testProperty
+                  "given a number that does not fit into Int, evaluate to error call"
+                  $ \(NonNegative number) text ->
+                    (ioProperty . fmap isLeft . try @ErrorCall . evaluate) $
+                      specimen
+                        (fromIntegral (number :: Int) + fromIntegral (maxBound :: Int) + 1)
+                        text
+              ]
+    ]

--- a/tests/Tests/Properties/CornerCases.hs
+++ b/tests/Tests/Properties/CornerCases.hs
@@ -22,8 +22,12 @@ testCornerCases =
         "stimes"
         $ let specimen = stimes :: Integer -> Text -> Text
           in  [ testProperty
-                  "given a negative number, return empty text"
-                  $ \(Negative number) text -> specimen number text == ""
+                  "given a negative number, evaluate to error call"
+                  $ \(Negative number) text ->
+                    (ioProperty . fmap isLeft . try @ErrorCall . evaluate) $
+                      specimen
+                        (fromIntegral (number :: Int))
+                        text
               , testProperty
                   "given a number that does not fit into Int, evaluate to error call"
                   $ \(NonNegative number) text ->

--- a/tests/Tests/Properties/Instances.hs
+++ b/tests/Tests/Properties/Instances.hs
@@ -7,6 +7,7 @@ module Tests.Properties.Instances
     ) where
 
 import Data.Binary (encode, decodeOrFail)
+import Data.Semigroup
 import Data.String (IsString(fromString))
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
@@ -37,6 +38,9 @@ t_Show            = show     `eq` (show . T.pack)
 tl_Show           = show     `eq` (show . TL.pack)
 t_mappend s       = mappend s`eqP` (unpackS . mappend (T.pack s))
 tl_mappend s      = mappend s`eqP` (unpackS . mappend (TL.pack s))
+t_stimes          = \ number -> eq
+  ((stimes :: Int -> String -> String) number . unSqrt)
+  (unpackS . (stimes :: Int -> T.Text -> T.Text) number . T.pack . unSqrt)
 t_mconcat         = (mconcat . unSqrt) `eq` (unpackS . mconcat . L.map T.pack . unSqrt)
 tl_mconcat        = (mconcat . unSqrt) `eq` (unpackS . mconcat . L.map TL.pack . unSqrt)
 t_mempty          = mempty === (unpackS (mempty :: T.Text))
@@ -71,6 +75,7 @@ testInstances =
     testProperty "tl_Show" tl_Show,
     testProperty "t_mappend" t_mappend,
     testProperty "tl_mappend" tl_mappend,
+    testProperty "t_stimes" t_stimes,
     testProperty "t_mconcat" t_mconcat,
     testProperty "tl_mconcat" tl_mconcat,
     testProperty "t_mempty" t_mempty,

--- a/text.cabal
+++ b/text.cabal
@@ -284,6 +284,7 @@ test-suite tests
     Tests.Properties.Substrings
     Tests.Properties.Text
     Tests.Properties.Transcoding
+    Tests.Properties.CornerCases
     Tests.Properties.Validate
     Tests.QuickCheckUtils
     Tests.RebindableSyntaxTest


### PR DESCRIPTION
Resolve #288.

There are two commits here.

* Commit № 1 adds two new benchmarks in the `Pure` section: one for `sconcat` and one for `stimes`.
* Commit № 2 adds specialized implementation of `sconcat` and `stimes` to the instance of `Semigroup` for strict `Text`.

The benchmarks can be run like so:

```sh
first_commit_hash='180645e'
pattern='$2 == "Pure" && ($4 == "sconcat" || $4 == "stimes") && $5 != "LazyText"'
git checkout "$first_commit_hash" &&
    cabal run text-benchmarks -- --pattern "$pattern" --timeout 10s --csv benchmarks.csv
git switch feature-sconcat-stimes &&
    cabal run text-benchmarks -- --pattern "$pattern" --timeout 10s --baseline benchmarks.csv --fail-if-slower 110
```

This will take a few minutes. You should see better times almost everywhere — only the `tiny.sconcat` will show worse times.

This is the report as seen on my machine:
```
All
  Pure
    tiny
      sconcat
        Text: FAIL
          38.6 ns ± 2.3 ns, 148% more than baseline
          Use -p '(($2=="Pure"&&($4=="sconcat"||$4=="stimes"))&&$5!="LazyText")&&/tiny.sconcat.Text/' to rerun this test only.
      stimes
        Text: OK
          70.7 ns ± 2.9 ns, 83% less than baseline
    ascii-small
      sconcat
        Text: OK
          18.6 μs ± 148 ns, 99% less than baseline
      stimes
        Text: OK
          125  μs ±  10 μs, 59% less than baseline
    ascii
      sconcat
        Text: OK
          28.7 ms ± 2.4 ms
      stimes
        Text: OK
          63.3 ms ± 5.6 ms, 78% less than baseline
    english
      sconcat
        Text: OK
          1.07 ms ± 7.4 μs
      stimes
        Text: OK
          4.40 ms ± 373 μs, 69% less than baseline
    russian
      sconcat
        Text: OK
          2.45 μs ± 224 ns, 95% less than baseline
      stimes
        Text: OK
          15.9 μs ± 736 ns, 62% less than baseline
    japanese
      sconcat
        Text: OK
          4.17 μs ± 175 ns, 97% less than baseline
      stimes
        Text: OK
          15.7 μs ± 1.4 μs, 63% less than baseline
```