### PR TITLE
improve test function write_read

### DIFF
--- a/tests/Tests/Properties/LowLevel.hs
+++ b/tests/Tests/Properties/LowLevel.hs
@@ -100,17 +100,14 @@ t_literal_foo = T.pack "foo"
 -- tl_put_get = write_read TL.unlines TL.filter put get
 --   where put h = withRedirect h IO.stdout . TL.putStr
 --         get h = withRedirect h IO.stdin TL.getContents
-t_write_read = write_read T.unlines T.filter T.hPutStr T.hGetContents
-tl_write_read = write_read TL.unlines TL.filter TL.hPutStr TL.hGetContents
+t_write_read = write_read T.unlines T.filter T.hPutStr T.hGetContents id
+tl_write_read = write_read TL.unlines TL.filter TL.hPutStr TL.hGetContents id
 
-t_write_read_line m b t = write_read (T.concat . take 1) T.filter T.hPutStrLn
-                            T.hGetLine m b [t]
-tl_write_read_line m b t = write_read (TL.concat . take 1) TL.filter TL.hPutStrLn
-                             TL.hGetLine m b [t]
+t_write_read_line = write_read (T.concat . take 1) T.filter T.hPutStrLn T.hGetLine (: [])
+tl_write_read_line = write_read (TL.concat . take 1) TL.filter TL.hPutStrLn TL.hGetLine (: [])
 
-utf8_write_read = write_read T.unlines T.filter TU.hPutStr TU.hGetContents
-utf8_write_read_line m b t = write_read (T.concat . take 1) T.filter TU.hPutStrLn
-                            TU.hGetLine m b [t]
+utf8_write_read = write_read T.unlines T.filter TU.hPutStr TU.hGetContents id
+utf8_write_read_line = write_read (T.concat . take 1) T.filter TU.hPutStrLn TU.hGetLine (: [])
 
 testLowLevel :: TestTree
 testLowLevel =
@@ -143,12 +140,12 @@ testLowLevel =
     ],
 
     testGroup "input-output" [
-      testProperty "t_write_read" t_write_read,
-      testProperty "tl_write_read" tl_write_read,
-      testProperty "t_write_read_line" t_write_read_line,
-      testProperty "tl_write_read_line" tl_write_read_line,
-      testProperty "utf8_write_read" utf8_write_read,
-      testProperty "utf8_write_read_line" utf8_write_read_line
+      testGroup "t_write_read" t_write_read,
+      testGroup "tl_write_read" tl_write_read,
+      testGroup "t_write_read_line" t_write_read_line,
+      testGroup "tl_write_read_line" tl_write_read_line,
+      testGroup "utf8_write_read" utf8_write_read,
+      testGroup "utf8_write_read_line" utf8_write_read_line
       -- These tests are subject to I/O race conditions
       -- testProperty "t_put_get" t_put_get,
       -- testProperty "tl_put_get" tl_put_get

--- a/tests/Tests/QuickCheckUtils.hs
+++ b/tests/Tests/QuickCheckUtils.hs
@@ -261,7 +261,7 @@ write_read unline filt writer reader nl buf ts
     IO.hSeek h IO.AbsoluteSeek 0
     r <- reader h
     let isEq = r == t
-    deepseq isEq $ pure $ counterexample (show r <> bool " /= " " == " isEq <> show t) isEq
+    deepseq isEq $ pure $ counterexample (show r ++ bool " /= " " == " isEq ++ show t) isEq
   where
     t = unline . map (filt (not . (`elem` "\r\n"))) $ ts
     encodings = [IO.utf8, IO.utf8_bom, IO.utf16, IO.utf16le, IO.utf16be, IO.utf32, IO.utf32le, IO.utf32be]

--- a/tests/Tests/QuickCheckUtils.hs
+++ b/tests/Tests/QuickCheckUtils.hs
@@ -35,7 +35,7 @@ import Data.Char (isSpace)
 import Data.Text.Foreign (I8)
 import Data.Text.Lazy.Builder.RealFloat (FPFormat(..))
 import Data.Word (Word8, Word16)
-import Test.QuickCheck (Arbitrary(..), arbitraryUnicodeChar, arbitraryBoundedEnum, getUnicodeString, arbitrarySizedIntegral, shrinkIntegral, Property, ioProperty, discard, counterexample, scale, (===), (.&&.), NonEmptyList(..), forAll)
+import Test.QuickCheck (Arbitrary(..), arbitraryUnicodeChar, arbitraryBoundedEnum, getUnicodeString, arbitrarySizedIntegral, shrinkIntegral, Property, ioProperty, discard, counterexample, scale, (===), (.&&.), NonEmptyList(..), forAll, withMaxSuccess)
 import Test.QuickCheck.Gen (Gen, choose, chooseAny, elements, frequency, listOf, oneof, resize, sized)
 import Tests.Utils
 import qualified Data.ByteString as B
@@ -249,7 +249,7 @@ write_read :: (Eq a, Show a)
            -> Property
 write_read _ _ _ _ (IO.NewlineMode IO.LF IO.CRLF) _ _ = discard
 write_read unline filt writer reader nl buf ts
-  = forAll (elements encodings) $ \enc -> ioProperty $ do
+  = withMaxSuccess 1000 $ forAll (elements encodings) $ \enc -> ioProperty $ do
     withTempFile $ \_ h -> do
     IO.hSetEncoding h enc
     IO.hSetNewlineMode h nl

--- a/tests/Tests/QuickCheckUtils.hs
+++ b/tests/Tests/QuickCheckUtils.hs
@@ -34,14 +34,13 @@ module Tests.QuickCheckUtils
     ) where
 
 import Control.Arrow ((***))
-import Control.DeepSeq (deepseq)
 import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.Text.Foreign (I8)
 import Data.Text.Lazy.Builder.RealFloat (FPFormat(..))
 import Data.Word (Word8, Word16)
 import GHC.IO.Encoding.Types (TextEncoding(TextEncoding,textEncodingName))
-import Test.QuickCheck (Arbitrary(..), arbitraryUnicodeChar, arbitraryBoundedEnum, getUnicodeString, arbitrarySizedIntegral, shrinkIntegral, Property, ioProperty, discard, counterexample, scale, (.&&.), NonEmptyList(..), suchThat, forAll, getPositive)
+import Test.QuickCheck (Arbitrary(..), arbitraryUnicodeChar, arbitraryBoundedEnum, getUnicodeString, arbitrarySizedIntegral, shrinkIntegral, Property, ioProperty, discard, counterexample, scale, (.&&.), NonEmptyList(..), forAll, getPositive)
 import Test.QuickCheck.Gen (Gen, choose, chooseAny, elements, frequency, listOf, oneof, resize, sized)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -276,12 +275,12 @@ write_read unline filt writer reader modData
     IO.hSeek h IO.AbsoluteSeek 0
     r <- reader h
     let isEq = r == t
-    deepseq isEq $ pure $ counterexample (show r ++ bool " /= " " == " isEq ++ show t) isEq
+    seq isEq $ pure $ counterexample (show r ++ bool " /= " " == " isEq ++ show t) isEq
+
   encodings = [IO.utf8, IO.utf8_bom, IO.utf16, IO.utf16le, IO.utf16be, IO.utf32, IO.utf32le, IO.utf32be]
 
   blockBuffering :: Gen IO.BufferMode
-  blockBuffering = IO.BlockBuffering <$> (fmap (fmap getPositive) arbitrary) `suchThat` maybe True (> 4)
-
+  blockBuffering = IO.BlockBuffering <$> fmap (fmap $ min 4 . getPositive) arbitrary
 
 -- Generate various Unicode space characters with high probability
 arbitrarySpacyChar :: Gen Char

--- a/tests/Tests/Utils.hs
+++ b/tests/Tests/Utils.hs
@@ -9,10 +9,10 @@ module Tests.Utils
     ) where
 
 import Control.Exception (SomeException, bracket, bracket_, evaluate, try)
-import Control.Monad (when)
+import Control.Monad (when, unless)
 import GHC.IO.Handle.Internals (withHandle)
 import System.Directory (removeFile)
-import System.IO (Handle, hClose, hFlush, hIsOpen, hIsWritable, openTempFile)
+import System.IO (Handle, hClose, hFlush, hIsOpen, hIsClosed, hIsWritable, openTempFile)
 import Test.QuickCheck (Property, ioProperty, property, (===), counterexample)
 
 -- Ensure that two potentially bottom values (in the sense of crashing
@@ -34,8 +34,8 @@ withTempFile :: (FilePath -> Handle -> IO a) -> IO a
 withTempFile = bracket (openTempFile "." "crashy.txt") cleanupTemp . uncurry
   where
     cleanupTemp (path,h) = do
-      open <- hIsOpen h
-      when open (hClose h)
+      closed <- hIsClosed h
+      unless closed $ hClose h
       removeFile path
 
 withRedirect :: Handle -> Handle -> IO a -> IO a

--- a/tests/Tests/Utils.hs
+++ b/tests/Tests/Utils.hs
@@ -9,10 +9,10 @@ module Tests.Utils
     ) where
 
 import Control.Exception (SomeException, bracket, bracket_, evaluate, try)
-import Control.Monad (when, unless)
+import Control.Monad (when)
 import GHC.IO.Handle.Internals (withHandle)
 import System.Directory (removeFile)
-import System.IO (Handle, hClose, hFlush, hIsOpen, hIsClosed, hIsWritable, openTempFile)
+import System.IO (Handle, hClose, hFlush, hIsOpen, hIsWritable, openTempFile)
 import Test.QuickCheck (Property, ioProperty, property, (===), counterexample)
 
 -- Ensure that two potentially bottom values (in the sense of crashing
@@ -34,8 +34,8 @@ withTempFile :: (FilePath -> Handle -> IO a) -> IO a
 withTempFile = bracket (openTempFile "." "crashy.txt") cleanupTemp . uncurry
   where
     cleanupTemp (path,h) = do
-      closed <- hIsClosed h
-      unless closed $ hClose h
+      open <- hIsOpen h
+      when open (hClose h)
       removeFile path
 
 withRedirect :: Handle -> Handle -> IO a -> IO a

--- a/text.cabal
+++ b/text.cabal
@@ -292,6 +292,7 @@ test-suite tests
     QuickCheck >= 2.12.6 && < 2.15,
     base <5,
     bytestring,
+    deepseq,
     directory,
     ghc-prim,
     tasty,

--- a/text.cabal
+++ b/text.cabal
@@ -292,7 +292,6 @@ test-suite tests
     QuickCheck >= 2.12.6 && < 2.15,
     base <5,
     bytestring,
-    deepseq,
     directory,
     ghc-prim,
     tasty,


### PR DESCRIPTION
Now tests different encodings not just UTF8.
Removed NFData constraint so that Builder can be tested.

Should be pulled before hPutStr and hPutBuilder PRs