### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,14 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230809
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230809
+            compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: true
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.8.2
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.6.5
+            compilerKind: ghc
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.6

--- a/text.cabal
+++ b/text.cabal
@@ -289,7 +289,7 @@ test-suite tests
     Tests.Utils
 
   build-depends:
-    QuickCheck >= 2.12.6 && < 2.15,
+    QuickCheck >= 2.12.6 && < 2.16,
     base <5,
     bytestring,
     deepseq,


### PR DESCRIPTION
Fix can be achieved on Hackage by a metadata edit.