### PR TITLE
Serialise Texts without going through ByteString

### DIFF
--- a/tests/Tests/Properties/Instances.hs
+++ b/tests/Tests/Properties/Instances.hs
@@ -6,6 +6,7 @@ module Tests.Properties.Instances
     ( testInstances
     ) where
 
+import Data.Binary (encode, decodeOrFail)
 import Data.String (IsString(fromString))
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
@@ -43,6 +44,16 @@ tl_mempty         = mempty === (unpackS (mempty :: TL.Text))
 t_IsString        = fromString  `eqP` (T.unpack . fromString)
 tl_IsString       = fromString  `eqP` (TL.unpack . fromString)
 
+t_Binary s        =
+  case decodeOrFail . encode $ (s :: T.Text) of
+    Left _   -> counterexample (show (T.unpack s)) (property False)
+    Right (_, _, s') -> s === s'
+
+tl_Binary s       =
+  case decodeOrFail . encode $ (s :: TL.Text) of
+    Left _   -> counterexample (show (TL.unpack s)) (property False)
+    Right (_, _, s') -> s === s'
+
 testInstances :: TestTree
 testInstances =
   testGroup "instances" [
@@ -65,5 +76,7 @@ testInstances =
     testProperty "t_mempty" t_mempty,
     testProperty "tl_mempty" tl_mempty,
     testProperty "t_IsString" t_IsString,
-    testProperty "tl_IsString" tl_IsString
+    testProperty "tl_IsString" tl_IsString,
+    testProperty "t_Binary" t_Binary,
+    testProperty "tl_Binary" tl_Binary
   ]

--- a/text.cabal
+++ b/text.cabal
@@ -294,6 +294,7 @@ test-suite tests
   build-depends:
     QuickCheck >= 2.12.6 && < 2.16,
     base <5,
+    binary,
     bytestring,
     deepseq,
     directory,


### PR DESCRIPTION
It has never been easier. Ever since text is using UTF-8 encoding internally we don't have to go through the intermediate ByteString step. However, we keep deserialisation as is to ensure proper UTF-8'ness.