### PR TITLE
Bump ghc-prim to accommodate 0.12

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -224,7 +224,7 @@ library
     binary           >= 0.5 && < 0.9,
     bytestring       >= 0.10.4 && < 0.13,
     deepseq          >= 1.1 && < 1.6,
-    ghc-prim         >= 0.2 && < 0.12,
+    ghc-prim         >= 0.2 && < 0.13,
     template-haskell >= 2.5 && < 2.23
 
   if impl(ghc < 9.4)


### PR DESCRIPTION
As this will be shipped with 9.12.2 per [GHC #25550](https://gitlab.haskell.org/ghc/ghc/-/issues/25550).