### PR TITLE
test: Use temporary to deal with temp files

### DIFF
--- a/.github/workflows/emulated.yml
+++ b/.github/workflows/emulated.yml
@@ -30,7 +30,7 @@ jobs:
         githubToken: ${{ github.token }}
         install: |
           apt-get update -y
-          apt-get install -y curl ghc libghc-tasty-quickcheck-dev libghc-tasty-hunit-dev
+          apt-get install -y curl ghc libghc-tasty-quickcheck-dev libghc-tasty-hunit-dev libghc-temporary-dev
         run: |
           curl -s https://hackage.haskell.org/package/data-array-byte-0.1/data-array-byte-0.1.tar.gz | tar xz
           ghc --version

--- a/benchmarks/haskell/Benchmarks.hs
+++ b/benchmarks/haskell/Benchmarks.hs
@@ -10,6 +10,7 @@ import System.FilePath ((</>))
 import System.IO
 
 #ifdef mingw32_HOST_OS
+import System.IO.Temp (emptySystemTempFile)
 import System.Directory (removeFile)
 #endif
 
@@ -40,11 +41,11 @@ import qualified Benchmarks.Programs.Throughput as Programs.Throughput
 mkSink :: IO (FilePath, Handle)
 mkSink = do
 #ifdef mingw32_HOST_OS
-    (sinkFn, sink) <- openTempFile "." "dev.null"
+    sinkFn <- emptySystemTempFile "dev.null"
 #else
     let sinkFn = "/dev/null"
-    sink <- openFile sinkFn  WriteMode
 #endif
+    sink <- openFile sinkFn WriteMode
     hSetEncoding sink utf8
     pure (sinkFn, sink)
 

--- a/tests/Tests/Regressions.hs
+++ b/tests/Tests/Regressions.hs
@@ -14,6 +14,7 @@ import Control.Exception (SomeException, handle)
 import Data.Char (isLetter, chr)
 import GHC.Exts (Int(..), sizeofByteArray#)
 import System.IO
+import System.IO.Temp (withSystemTempFile)
 import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure)
 import qualified Data.ByteString as B
 import Data.ByteString.Char8 ()
@@ -33,7 +34,6 @@ import qualified Data.Text.Unsafe as T
 import qualified Test.Tasty as F
 import qualified Test.Tasty.HUnit as F
 import Test.Tasty.HUnit ((@?=))
-import System.Directory (removeFile)
 
 import Tests.Utils (withTempFile)
 
@@ -48,15 +48,13 @@ lazy_encode_crash = withTempFile $ \ _ h ->
 -- encoded file can result in a crash in the RTS (i.e. not merely an
 -- exception).
 hGetContents_crash :: IO ()
-hGetContents_crash = do
-  (path, h) <- openTempFile "." "crashy.txt"
+hGetContents_crash = withSystemTempFile "crashy.txt" $ \path h -> do
   B.hPut h (B.pack [0x78, 0xc4 ,0x0a]) >> hClose h
   h' <- openFile path ReadMode
   hSetEncoding h' utf8
   handle (\(_::SomeException) -> return ()) $
     T.hGetContents h' >> assertFailure "T.hGetContents should crash"
   hClose h'
-  removeFile path
 
 -- Reported by Ian Lynagh: attempting to allocate a sufficiently large
 -- string (via either Array.new or Text.replicate) could result in an

--- a/tests/Tests/Utils.hs
+++ b/tests/Tests/Utils.hs
@@ -8,11 +8,11 @@ module Tests.Utils
     , withTempFile
     ) where
 
-import Control.Exception (SomeException, bracket, bracket_, evaluate, try)
-import Control.Monad (when, unless)
+import Control.Exception (SomeException, bracket_, evaluate, try)
+import Control.Monad (when)
+import System.IO.Temp (withSystemTempFile)
 import GHC.IO.Handle.Internals (withHandle)
-import System.Directory (removeFile)
-import System.IO (Handle, hClose, hFlush, hIsOpen, hIsClosed, hIsWritable, openTempFile)
+import System.IO (Handle, hFlush, hIsOpen, hIsWritable)
 import Test.QuickCheck (Property, ioProperty, property, (===), counterexample)
 
 -- Ensure that two potentially bottom values (in the sense of crashing
@@ -31,12 +31,7 @@ infix 4 =^=
 {-# NOINLINE (=^=) #-}
 
 withTempFile :: (FilePath -> Handle -> IO a) -> IO a
-withTempFile = bracket (openTempFile "." "crashy.txt") cleanupTemp . uncurry
-  where
-    cleanupTemp (path,h) = do
-      closed <- hIsClosed h
-      unless closed $ hClose h
-      removeFile path
+withTempFile = withSystemTempFile "crashy.txt"
 
 withRedirect :: Handle -> Handle -> IO a -> IO a
 withRedirect tmp h = bracket_ swap swap

--- a/text.cabal
+++ b/text.cabal
@@ -299,12 +299,12 @@ test-suite tests
     binary,
     bytestring,
     deepseq,
-    directory,
     ghc-prim,
     tasty,
     tasty-hunit,
     tasty-quickcheck,
     template-haskell,
+    temporary,
     transformers,
     text
   if impl(ghc < 9.4)
@@ -313,7 +313,6 @@ test-suite tests
   -- ghc-9.2.1 library depends on parsec, which causes a circular dependency.
   if impl(ghc >= 8.2.1 && < 8.6 || >= 8.6.2 && < 9.2 || >= 9.2.2)
     build-depends: tasty-inspection-testing
-
   default-language: Haskell2010
   default-extensions: NondecreasingIndentation
 
@@ -333,6 +332,7 @@ benchmark text-benchmarks
                   directory,
                   filepath,
                   tasty-bench >= 0.2,
+                  temporary,
                   text,
                   transformers
 


### PR DESCRIPTION
To avoid flooding the current directory with temp files when testing.