### PR TITLE
Support for GHC 9.12 and GHC 9.14

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -225,8 +225,8 @@ library
     binary           >= 0.5 && < 0.9,
     bytestring       >= 0.10.4 && < 0.13,
     deepseq          >= 1.1 && < 1.6,
-    ghc-prim         >= 0.2 && < 0.14,
-    template-haskell >= 2.5 && < 2.24
+    ghc-prim         >= 0.2 && < 0.15,
+    template-haskell >= 2.5 && < 2.25
 
   if impl(ghc < 9.4)
     build-depends: data-array-byte >= 0.1 && < 0.2


### PR DESCRIPTION
The MR includes two commits:
 * the first merges the commit reachable from GHC's upstream 9.12 branch bumping `base` and `template-haskell` bounds for GHC 9.12.1.
 * the second does the same for GHC 9.14
