### PR TITLE
chore: Add comprehensive documentation for `hGetChunk` (#651)

### DIFF
--- a/src/Data/Text/IO.hs
+++ b/src/Data/Text/IO.hs
@@ -116,14 +116,14 @@ readChunkEof hh buf = do t <- readChunk hh buf
 -- cannot guarantee reading an exact number of bytes. Instead, it reads
 -- complete characters up to the handle's internal buffer limit.
 --
--- == Buffer Size
+-- === Buffer Size
 --
 -- The maximum chunk size is determined by the handle's internal character
 -- buffer, which is set to 2048 characters (not bytes) by the GHC runtime
 -- constant @dEFAULT_CHAR_BUFFER_SIZE@. This buffer size cannot be modified
 -- through any public API.
 --
--- == UTF-8 Considerations
+-- === UTF-8 Considerations
 --
 -- When working with UTF-8 encoded text:
 --

--- a/src/Data/Text/IO.hs
+++ b/src/Data/Text/IO.hs
@@ -119,7 +119,7 @@ readChunkEof hh buf = do t <- readChunk hh buf
 -- === Buffer Size
 --
 -- The maximum chunk size is determined by the handle's internal character
--- buffer, which is set to 2048 characters (not bytes) by the GHC runtime
+-- buffer, which is set to 8192 bytes (2048 characters) by the GHC runtime
 -- constant @dEFAULT_CHAR_BUFFER_SIZE@. This buffer size cannot be modified
 -- through any public API.
 --

--- a/src/Data/Text/IO.hs
+++ b/src/Data/Text/IO.hs
@@ -109,7 +109,7 @@ readChunkEof hh buf = do t <- readChunk hh buf
 -- has not yet been reached. Once EOF is reached, this function
 -- returns an empty string instead of throwing an exception.
 --
--- == Behavior
+-- === Behavior
 --
 -- Unlike byte-oriented functions, 'hGetChunk' operates on complete UTF-8
 -- characters. Since UTF-8 characters can occupy 1 to 4 bytes, this function

--- a/src/Data/Text/IO.hs
+++ b/src/Data/Text/IO.hs
@@ -101,13 +101,35 @@ readChunkEof :: Handle__ -> CharBuffer -> IO (Text, Bool)
 readChunkEof hh buf = do t <- readChunk hh buf
                          return (t, False)
 
--- | /Experimental./ Read a single chunk of strict text from a
+-- | Read a single chunk of strict text from a
 -- 'Handle'. The size of the chunk depends on the amount of input
 -- currently buffered.
 --
 -- This function blocks only if there is no data available, and EOF
 -- has not yet been reached. Once EOF is reached, this function
 -- returns an empty string instead of throwing an exception.
+--
+-- == Behavior
+--
+-- Unlike byte-oriented functions, 'hGetChunk' operates on complete UTF-8
+-- characters. Since UTF-8 characters can occupy 1 to 4 bytes, this function
+-- cannot guarantee reading an exact number of bytes. Instead, it reads
+-- complete characters up to the handle's internal buffer limit.
+--
+-- == Buffer Size
+--
+-- The maximum chunk size is determined by the handle's internal character
+-- buffer, which is set to 2048 characters (not bytes) by the GHC runtime
+-- constant @dEFAULT_CHAR_BUFFER_SIZE@. This buffer size cannot be modified
+-- through any public API.
+--
+-- == UTF-8 Considerations
+--
+-- When working with UTF-8 encoded text:
+--
+-- * The function will never return a partial character
+-- * The actual number of bytes read may vary depending on the character
+--   encoding (ASCII characters = 1 byte, other Unicode characters = 2-4 bytes)
 hGetChunk :: Handle -> IO Text
 hGetChunk h = wantReadableHandle "hGetChunk" h readSingleChunk
  where


### PR DESCRIPTION
## Summary
This PR adds detailed Haddock documentation for the `hGetChunk` function to clarify its behavior regarding UTF-8 character boundaries and buffer limitations.

## Motivation
The existing documentation didn't clearly explain why `hGetChunk` cannot guarantee reading an exact number of bytes. Users expecting byte-oriented behavior similar to `ByteString.hGetSome` may be confused by the character-oriented nature of Text operations.

## Changes
- Added comprehensive Haddock documentation covering:
  - UTF-8 character boundary handling (characters can be 1-4 bytes)
  - Internal buffer limitation (2048 characters via `dEFAULT_CHAR_BUFFER_SIZE`)
  - Clear distinction from byte-oriented operations
  - Clarifies the non-configurable buffer size limitation