### PR TITLE
Switch from template-haskell to template-haskell-lift

### DIFF
--- a/tests/Tests/Lift.hs
+++ b/tests/Tests/Lift.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Tests.Lift
@@ -7,7 +8,11 @@ module Tests.Lift
 
 import qualified Data.Text as S
 import qualified Data.Text.Lazy as L
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (lift)
+#else
 import Language.Haskell.TH.Syntax (lift)
+#endif
 import Test.Tasty.HUnit (testCase, assertEqual)
 import Test.Tasty (TestTree, testGroup)
 

--- a/tests/Tests/RebindableSyntaxTest.hs
+++ b/tests/Tests/RebindableSyntaxTest.hs
@@ -1,9 +1,13 @@
-{-# LANGUAGE RebindableSyntax, TemplateHaskell #-}
+{-# LANGUAGE CPP, RebindableSyntax, TemplateHaskell #-}
 
 module Tests.RebindableSyntaxTest where
 
 import qualified Data.Text as Text
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (lift)
+#else
 import Language.Haskell.TH.Syntax (lift)
+#endif
 import Test.Tasty.HUnit (testCase, assertEqual)
 import Test.Tasty (TestTree, testGroup)
 import Prelude (($))

--- a/tests/Tests/ShareEmpty.hs
+++ b/tests/Tests/ShareEmpty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -12,7 +13,11 @@ module Tests.ShareEmpty
 
 import Control.Exception (evaluate)
 import Data.Text
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (lift)
+#else
 import Language.Haskell.TH.Syntax (lift)
+#endif
 import Test.Tasty.HUnit (testCase, assertFailure, assertEqual)
 import Test.Tasty (TestTree, testGroup)
 import GHC.Exts

--- a/text.cabal
+++ b/text.cabal
@@ -227,7 +227,14 @@ library
     bytestring       >= 0.10.4 && < 0.13,
     deepseq          >= 1.1 && < 1.6,
     ghc-prim         >= 0.2 && < 0.15,
-    template-haskell >= 2.5 && < 2.25
+
+  -- template-haskell-lift was added as a boot library in GHC-9.14
+  -- once we no longer wish to backport releases to older major releases of GHC,
+  -- this conditional can be dropped
+  if impl(ghc < 9.14)
+    build-depends: template-haskell >= 2.5 && < 3
+  else
+    build-depends: template-haskell-lift >= 0.1 && <0.2
 
   if impl(ghc < 9.4)
     build-depends: data-array-byte >= 0.1 && < 0.2
@@ -304,12 +311,15 @@ test-suite tests
     tasty,
     tasty-hunit,
     tasty-quickcheck,
-    template-haskell,
     temporary,
     transformers,
     text
   if impl(ghc < 9.4)
     build-depends: data-array-byte >= 0.1 && < 0.2
+  if impl(ghc < 9.14)
+    build-depends: template-haskell
+  else
+    build-depends: template-haskell-lift
 
   -- Plugin infrastructure does not work properly in 8.6.1, and
   -- ghc-9.2.1 library depends on parsec, which causes a circular dependency.


### PR DESCRIPTION
We switch our dependency on template-haskell to a dependency on template-haskell-lift. This smaller library is more stabler and if we can remove the template-haskell dependency from all boot libraries then template-haskell will be much easier to re-install since it no longer needs to be in GHC's dependency closure.

For more information see the GHC proposal that introduced this library: https://github.com/ghc-proposals/ghc-proposals/pull/696

This GHC MR tests this PR against GHC-HEAD: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14978