### PR TITLE
Bump lower bound of binary to >= 0.8.3

### DIFF
--- a/text.cabal
+++ b/text.cabal
@@ -222,7 +222,7 @@ library
   build-depends:
     array            >= 0.3 && < 0.6,
     base             >= 4.11 && < 5,
-    binary           >= 0.5 && < 0.9,
+    binary           >= 0.8.3 && < 0.9,
     bytestring       >= 0.10.4 && < 0.13,
     deepseq          >= 1.1 && < 1.6,
     ghc-prim         >= 0.2 && < 0.15,


### PR DESCRIPTION
Fix #672

I've also updated the bounds on Hackage for 2.1.2 and 2.1.3