### PR TITLE
Avoid calling `length` on chunks in lazy `splitAt`

### DIFF
--- a/src/Data/Text/Lazy.hs
+++ b/src/Data/Text/Lazy.hs
@@ -1307,6 +1307,8 @@ splitAt = loop
     loop !_ Empty     = (empty, empty)
     loop n t | n <= 0 = (empty, t)
     loop n (Chunk t@(T.Text arr off len) ts)
+         | n > mx = let (ts', ts'') = loop (n - intToInt64 (T.length t)) ts
+                    in (Chunk t ts', ts'')
          | m > 0, m >= len = (Chunk t Empty, ts)
          | m > 0 = let t' = T.Text arr off m
                        t'' = T.Text arr (off+m) (len-m)
@@ -1314,9 +1316,8 @@ splitAt = loop
          | otherwise = let (ts', ts'') = loop (n + intToInt64 m) ts
                        in (Chunk t ts', ts'')
          where
-         k | n > intToInt64 len = len+1
-           | otherwise = int64ToInt n
-         m = T.measureOff k t
+         mx = intToInt64 P.maxBound
+         m = T.measureOff (int64ToInt n) t
 
 
 -- | /O(n)/ 'splitAtWord' @n t@ returns a strict pair whose first


### PR DESCRIPTION
This PR tweaks the implementation of the lazy `splitAt` to avoid calling `length` on the strict `Text` chunks.

While doing some experimenting, I found that producing a lazy text with a very large chunk had disastrous effects for a parser consuming that text. The reason is that the parser was calling `splitAt` to chop up the input, and that repeatedly counts _all_ the characters in the input chunks.

The strict `splitAt` uses the `measureOff` function to split, which either reports where to partition the underlying array, or tells you how many characters are in the `Text` if it isn't long enough (with a negated result). So, I switched to using this in the lazy loop.

I haven't done extensive benchmarking, but it seems like even on reasonably chunked input, my parser runs faster with this than with the old version.