### PR TITLE
Fix typos

### DIFF
--- a/simdutf/simdutf.cpp
+++ b/simdutf/simdutf.cpp
@@ -5690,7 +5690,7 @@ result base64_tail_decode(char *dst, const char_type *src, size_t length, base64
   }
 }
 
-// like base64_tail_decode, but it will not write past the end of the ouput buffer.
+// like base64_tail_decode, but it will not write past the end of the output buffer.
 // outlen is modified to reflect the number of bytes written.
 // This functions assumes that the padding (=) has been removed.
 template <class char_type>
@@ -6777,7 +6777,7 @@ internal::atomic_ptr<const implementation>& get_default_implementation() {
   return get_active_implementation();
 }
 #endif
-#define SIMDUTF_GET_CURRENT_IMPLEMENTION
+#define SIMDUTF_GET_CURRENT_IMPLEMENTATION
 
 simdutf_warn_unused bool validate_utf8(const char *buf, size_t len) noexcept {
   return get_default_implementation()->validate_utf8(buf, len);
@@ -35063,7 +35063,7 @@ std::pair<const char32_t*, char*> sse_convert_utf32_to_utf8(const char32_t* buf,
       // t0 = [000a|aaaa|bbbb|bb00]
       const __m128i t0 = _mm_slli_epi16(in_16, 2); // shift packed vector by two
       // t1 = [000a|aaaa|0000|0000]
-      const __m128i t1 = _mm_and_si128(t0, v_1f00); // potentital first utf8 byte
+      const __m128i t1 = _mm_and_si128(t0, v_1f00); // potential first utf8 byte
       // t2 = [0000|0000|00bb|bbbb]
       const __m128i t2 = _mm_and_si128(in_16, v_003f);// potential second utf8 byte
       // t3 = [000a|aaaa|00bb|bbbb]

--- a/simdutf/simdutf.h
+++ b/simdutf/simdutf.h
@@ -2328,7 +2328,7 @@ simdutf_warn_unused size_t maximal_binary_length_from_base64(const char * input,
 simdutf_warn_unused size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) noexcept;
 
 /**
- * Convert a base64 input to a binary ouput.
+ * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it will
  * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -2365,7 +2365,7 @@ simdutf_warn_unused result base64_to_binary(const char * input, size_t length, c
 simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_options options = base64_default) noexcept;
 
 /**
- * Convert a binary input to a base64 ouput. The output is always padded with equal signs so that it is
+ * Convert a binary input to a base64 output. The output is always padded with equal signs so that it is
  * a multiple of 4 bytes long.
  *
  * This function always succeeds.
@@ -2379,7 +2379,7 @@ simdutf_warn_unused size_t base64_length_from_binary(size_t length, base64_optio
 size_t binary_to_base64(const char * input, size_t length, char* output, base64_options options = base64_default) noexcept;
 
 /**
- * Convert a base64 input to a binary ouput.
+ * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it will
  * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -2408,7 +2408,7 @@ size_t binary_to_base64(const char * input, size_t length, char* output, base64_
 simdutf_warn_unused result base64_to_binary(const char16_t * input, size_t length, char* output, base64_options options = base64_default)  noexcept;
 
 /**
- * Convert a base64 input to a binary ouput.
+ * Convert a base64 input to a binary output.
  *
  * This function follows the WHATWG forgiving-base64 format, which means that it will
  * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -3531,7 +3531,7 @@ public:
   simdutf_warn_unused virtual size_t maximal_binary_length_from_base64(const char16_t * input, size_t length) const noexcept = 0;
 
   /**
-   * Convert a base64 input to a binary ouput.
+   * Convert a base64 input to a binary output.
    *
    * This function follows the WHATWG forgiving-base64 format, which means that it will
    * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -3556,7 +3556,7 @@ public:
   simdutf_warn_unused virtual result base64_to_binary(const char * input, size_t length, char* output, base64_options options = base64_default) const noexcept = 0;
 
   /**
-   * Convert a base64 input to a binary ouput.
+   * Convert a base64 input to a binary output.
    *
    * This function follows the WHATWG forgiving-base64 format, which means that it will
    * ignore any ASCII spaces in the input. You may provide a padded input (with one or two
@@ -3584,13 +3584,13 @@ public:
    * Provide the base64 length in bytes given the length of a binary input.
    *
    * @param length        the length of the input in bytes
-   * @parem options       the base64 options to use, can be base64_default or base64_url, is base64_default by default.
+   * @param options       the base64 options to use, can be base64_default or base64_url, is base64_default by default.
    * @return number of base64 bytes
    */
   simdutf_warn_unused virtual size_t base64_length_from_binary(size_t length, base64_options options = base64_default) const noexcept = 0;
 
   /**
-   * Convert a binary input to a base64 ouput. The output is always padded with equal signs so that it is
+   * Convert a binary input to a base64 output. The output is always padded with equal signs so that it is
    * a multiple of 4 bytes long.
    *
    * This function always succeeds.

--- a/src/Data/Text/Internal/Builder.hs
+++ b/src/Data/Text/Internal/Builder.hs
@@ -319,7 +319,7 @@ newBuffer size = do
 -- Some nice rules for Builder
 
 -- This function makes GHC understand that 'writeN' and 'ensureFree'
--- are *not* recursive in the precense of the rewrite rules below.
+-- are *not* recursive in the presence of the rewrite rules below.
 -- This is not needed with GHC 7+.
 append' :: Builder -> Builder -> Builder
 append' (Builder f) (Builder g) = Builder (f . g)


### PR DESCRIPTION
Found via `codespell -L te,vew,out,yot,lamda,ot,tje,seh,otu,cche,ue,bu,yhe,writen,clen,ofo,alo,hask` and `typos --hidden --format brief`