### PR TITLE
Workaround fix for inspection test broken by GHC 9.14

### DIFF
--- a/tests/Tests/Properties/Folds.hs
+++ b/tests/Tests/Properties/Folds.hs
@@ -273,6 +273,7 @@ testFolds =
       testProperty "t_foldlM'" t_foldlM',
       testProperty "tl_foldlM'" tl_foldlM',
 #ifdef MIN_VERSION_tasty_inspection_testing
+      let _unused = ['_S_foldl'_from_foldlM', '_S_foldl'] in
       $(inspectTest ('_S_foldl'_from_foldlM' ==~ '_S_foldl')),
 #endif
       testCase "fold_apart" fold_apart,

--- a/tests/Tests/Properties/LowLevel.hs
+++ b/tests/Tests/Properties/LowLevel.hs
@@ -160,7 +160,9 @@ testLowLevel =
       testCase "t_literal_length2" t_literal_length2,
       testCase "t_literal_surrogates" t_literal_surrogates
 #ifdef MIN_VERSION_tasty_inspection_testing
-      , $(inspectObligations
+        -- Hack to force GHC to keep the binding around until this is fixed: https://gitlab.haskell.org/ghc/ghc/-/issues/26436
+      , let _unused = 't_literal_foo in
+        $(inspectObligations
         [ (`hasNoTypes` [''Char, ''[]])
         , (`doesNotUseAnyOf` ['T.pack, 'S.unstream, 'T.map, 'safe, 'S.streamList])
         , (`doesNotUseAnyOf` ['GHC.unpackCString#, 'GHC.unpackCStringUtf8#])


### PR DESCRIPTION
GHC 9.14 broke inspection-testing by removing unused bindings that turn out to be used (via TH or ANN). The workaround is to trick GHC into keeping these bindings. GHC issue: https://gitlab.haskell.org/ghc/ghc/-/issues/26436