### PR TITLE
Return length of 1 for continuation bytes

### DIFF
--- a/src/Data/Text/Internal/Encoding/Utf8.hs
+++ b/src/Data/Text/Internal/Encoding/Utf8.hs
@@ -82,13 +82,14 @@ utf8Length :: Char -> Int
 utf8Length (C# c) = I# ((1# +# geChar# c (chr# 0x80#)) +# (geChar# c (chr# 0x800#) +# geChar# c (chr# 0x10000#)))
 {-# INLINE utf8Length #-}
 
--- | Measure byte length of UTF-8 encoding for characters,
--- starting with a given byte.
+-- | Measure byte length of UTF-8 encoding for characters
+-- starting with the given leading byte.
+-- Continuation bytes yield a fail-safe value of 1.
 --
 -- @since 2.0
 utf8LengthByLeader :: Word8 -> Int
 utf8LengthByLeader w
-  | w < 0x80  = 1
+  | w < 0xC0  = 1
   | w < 0xE0  = 2
   | w < 0xF0  = 3
   | otherwise = 4


### PR DESCRIPTION
A continuation byte is always at least one byte long; returning a length of two makes accidental out of bound reads more likely. This reverts a change in behaviour in 2.1.3+ due to 1373ce315b30d24290282de8b5c8b1e8559173a0

Fixes #704